### PR TITLE
add more aliases to `smoothscroll`

### DIFF
--- a/polyfills/smoothscroll/config.toml
+++ b/polyfills/smoothscroll/config.toml
@@ -1,12 +1,15 @@
 aliases = [
 	"scroll",
 	"scrollBy",
+	"window.scrollTo",
 	"scrollIntoView",
 	"Element.prototype.scroll",
 	"Element.prototype.scrollBy",
+	"Element.prototype.scrollTo",
 	"Element.prototype.scrollIntoView",
 	"window.scroll",
-	"window.scrollBy"
+	"window.scrollBy",
+	"window.scrollTo"
 ]
 dependencies = [
 	"requestAnimationFrame",

--- a/polyfills/smoothscroll/config.toml
+++ b/polyfills/smoothscroll/config.toml
@@ -1,7 +1,7 @@
 aliases = [
 	"scroll",
 	"scrollBy",
-	"window.scrollTo",
+	"scrollTo",
 	"scrollIntoView",
 	"Element.prototype.scroll",
 	"Element.prototype.scrollBy",

--- a/polyfills/smoothscroll/tests.js
+++ b/polyfills/smoothscroll/tests.js
@@ -24,6 +24,17 @@ describe('scrollBy', function () {
 	});
 });
 
+describe('scrollTo', function () {
+	it('is defined as a function on window', function () {
+		proclaim.isTypeOf(window.scrollTo, 'function');
+	});
+
+	it('is defined as a function on Element.prototype', function () {
+		var Element = window.HTMLElement || window.Element;
+		proclaim.isTypeOf(Element.prototype.scrollTo, 'function');
+	});
+});
+
 describe('scrollIntoView', function () {
 	it('is defined as a function on Element.prototype', function () {
 		var Element = window.HTMLElement || window.Element;


### PR DESCRIPTION
`scrollTo` is also covered by the polyfill but it wasn't listed in the aliases.