### PR TITLE
change exhaustive tests

### DIFF
--- a/.github/workflows/test-polyfills-exhaustive.yml
+++ b/.github/workflows/test-polyfills-exhaustive.yml
@@ -1,7 +1,8 @@
-name: Test Polyfills Weekly
+name: Test Polyfills Exhaustive
 on:
-  schedule:
-    - cron: '0 23 * * 0' # TODO : set convenient weekly retest time
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This test suite does two things differently from the pull request triggered version:
- always test all browser versions
- also test all polyfills in combination with all other polyfills

We mostly want to have run this at least once before releasing.
Running on a schedule is a bit annoying because of how often it fails.
If it runs on pushes to `main` it will still fail as often but re-running failed jobs will actually make a difference.

This also adds one more retry mechanic to address the underlying issue that Browserstack is very flaky. When loading the url with the test content fails it will also retry. 

Failing the actual test does not retry at this level.