### PR TITLE
Adds `set-methods` polyfills

### DIFF
--- a/polyfills/Set/prototype/difference/config.toml
+++ b/polyfills/Set/prototype/difference/config.toml
@@ -1,0 +1,29 @@
+aliases = [ "es2025" ]
+dependencies = [
+	"_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.GetIterator",
+	"_ESAbstract.GetSetRecord",
+	"_ESAbstract.IteratorStepValue",
+	"_ESAbstract.ToBoolean",
+	"Set",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-set.prototype.difference"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<122"
+edge = "*"
+firefox = "<127"
+firefox_mob = "<127"
+ie = "*"
+ie_mob = "*"
+opera = "<108"
+op_mob = "<81"
+op_mini = "*"
+safari = "<17.0"
+ios_saf = "<17.0"
+samsung_mob = "*"

--- a/polyfills/Set/prototype/difference/detect.js
+++ b/polyfills/Set/prototype/difference/detect.js
@@ -1,0 +1,2 @@
+/* global Set */
+"difference" in Set.prototype;

--- a/polyfills/Set/prototype/difference/polyfill.js
+++ b/polyfills/Set/prototype/difference/polyfill.js
@@ -1,0 +1,70 @@
+/* global Call, CreateMethodProperty, GetIterator, GetSetRecord, IteratorStepValue, Set, ToBoolean */
+// 24.2.4.5 Set.prototype.difference ( other )
+CreateMethodProperty(Set.prototype, "difference", function difference(other) {
+	// 1. Let O be the this value.
+	var O = this;
+	// 2. Perform ? RequireInternalSlot(O, [[SetData]]).
+	Set.prototype.has.call(O);
+	// 3. Let otherRec be ? GetSetRecord(other).
+	var otherRec = GetSetRecord(other);
+	// 4. Let resultSetData be a copy of O.[[SetData]].
+	var result = new Set();
+	O.forEach(function (value) {
+		result.add(value);
+	});
+	// 5. If SetDataSize(O.[[SetData]]) ≤ otherRec.[[Size]], then
+	if (O.size <= otherRec["[[Size]]"]) {
+		// a. Let thisSize be the number of elements in O.[[SetData]].
+		var thisSize = O.size;
+		// b. Let index be 0.
+		var index = 0;
+		// c. Repeat, while index < thisSize,
+		result.forEach(
+			// i. Let e be resultSetData[index].
+			function (e) {
+				if (index < thisSize) {
+					// ii. If e is not empty, then
+					// 1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
+					var inOther = ToBoolean(
+						Call(otherRec["[[Has]]"], otherRec["[[SetObject]]"], [e])
+					);
+					// 2. If inOther is true, then
+					if (inOther === true) {
+						// a. Set resultSetData[index] to empty.
+						result.delete(e);
+					}
+					// iii. Set index to index + 1.
+					index = index + 1;
+				}
+			}
+		);
+	}
+	// 6. Else,
+	else {
+		// a. Let keysIter be ? GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]]).
+		var keysIter = GetIterator(otherRec["[[SetObject]]"], otherRec["[[Keys]]"]);
+		// b. Let next be not-started.
+		var next;
+		// c. Repeat, while next is not done,
+		while (!keysIter["[[Done]]"]) {
+			// i. Set next to ? IteratorStepValue(keysIter).
+			next = IteratorStepValue(keysIter);
+			// ii. If next is not done, then
+			if (!keysIter["[[Done]]"]) {
+				// 1. Set next to CanonicalizeKeyedCollectionKey(next).
+				// eslint-disable-next-line no-compare-neg-zero
+				if (next === -0) next = 0;
+				// 2. Let valueIndex be SetDataIndex(resultSetData, next).
+				// 3. If valueIndex is not not-found, then
+				if (result.has(next)) {
+					// a. Set resultSetData[valueIndex] to empty.
+					result.delete(next);
+				}
+			}
+		}
+	}
+	// 7. Let result be OrdinaryObjectCreate(%Set.prototype%, « [[SetData]] »).
+	// 8. Set result.[[SetData]] to resultSetData.
+	// 9. Return result.
+	return result;
+});

--- a/polyfills/Set/prototype/difference/tests.js
+++ b/polyfills/Set/prototype/difference/tests.js
@@ -1,0 +1,44 @@
+/* global Set */
+
+it("is a function", function () {
+	proclaim.isFunction(Set.prototype.difference);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Set.prototype.difference, 1);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Set.prototype.difference, "difference");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Set.prototype, "difference");
+});
+
+describe("difference", function () {
+	it("should compute the difference of a set with a smaller set", function () {
+		var set = new Set([1, 2, 3]).difference(new Set([3, 4]));
+		proclaim.equal(set.size, 2);
+		proclaim.isTrue(set.has(1));
+		proclaim.isTrue(set.has(2));
+	});
+
+	it("should compute the difference of a set with a larger set", function () {
+		var set = new Set([3, 4]).difference(new Set([1, 2, 3]));
+		proclaim.equal(set.size, 1);
+		proclaim.isTrue(set.has(4));
+	});
+
+	it("should throw for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Set.prototype.difference.call({}, new Set());
+		}, TypeError);
+	});
+
+	it("should throw for an invalid `other`", function () {
+		proclaim.throws(function () {
+			Set.prototype.difference.call(new Set(), {});
+		}, TypeError);
+	});
+});

--- a/polyfills/Set/prototype/intersection/config.toml
+++ b/polyfills/Set/prototype/intersection/config.toml
@@ -1,0 +1,29 @@
+aliases = [ "es2025" ]
+dependencies = [
+	"_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.GetIterator",
+	"_ESAbstract.GetSetRecord",
+	"_ESAbstract.IteratorStepValue",
+	"_ESAbstract.ToBoolean",
+	"Set",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-set.prototype.intersection"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/intersection"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<122"
+edge = "*"
+firefox = "<127"
+firefox_mob = "<127"
+ie = "*"
+ie_mob = "*"
+opera = "<108"
+op_mob = "<81"
+op_mini = "*"
+safari = "<17.0"
+ios_saf = "<17.0"
+samsung_mob = "*"

--- a/polyfills/Set/prototype/intersection/detect.js
+++ b/polyfills/Set/prototype/intersection/detect.js
@@ -1,0 +1,2 @@
+/* global Set */
+"intersection" in Set.prototype;

--- a/polyfills/Set/prototype/intersection/polyfill.js
+++ b/polyfills/Set/prototype/intersection/polyfill.js
@@ -1,0 +1,86 @@
+/* global Call, CreateMethodProperty, GetIterator, GetSetRecord, IteratorStepValue, Set, ToBoolean */
+// 24.2.4.9 Set.prototype.intersection ( other )
+CreateMethodProperty(
+	Set.prototype,
+	"intersection",
+	function intersection(other) {
+		// 1. Let O be the this value.
+		var O = this;
+		// 2. Perform ? RequireInternalSlot(O, [[SetData]]).
+		Set.prototype.has.call(O);
+		// 3. Let otherRec be ? GetSetRecord(other).
+		var otherRec = GetSetRecord(other);
+		// 4. Let resultSetData be a new empty List.
+		var result = new Set();
+		// 5. If SetDataSize(O.[[SetData]]) ≤ otherRec.[[Size]], then
+		if (O.size <= otherRec["[[Size]]"]) {
+			// a. Let thisSize be the number of elements in O.[[SetData]].
+			var thisSize = O.size;
+			// b. Let index be 0.
+			var index = 0;
+			// c. Repeat, while index < thisSize,
+			O.forEach(
+				// i. Let e be O.[[SetData]][index].
+				function (e) {
+					if (index < thisSize) {
+						// ii. Set index to index + 1.
+						index = index + 1;
+						// iii. If e is not empty, then
+						// 1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
+						var inOther = ToBoolean(
+							Call(otherRec["[[Has]]"], otherRec["[[SetObject]]"], [e])
+						);
+						// 2. If inOther is true, then
+						if (inOther === true) {
+							// a. NOTE: It is possible for earlier calls to otherRec.[[Has]] to remove and re-add an element of O.[[SetData]], which can cause the same element to be visited twice during this iteration.
+							// b. If SetDataHas(resultSetData, e) is false, then
+							if (result.has(e) === false) {
+								// i. Append e to resultSetData.
+								result.add(e);
+							}
+						}
+						// 3. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
+						// 4. Set thisSize to the number of elements in O.[[SetData]].
+						thisSize = O.size;
+					}
+				}
+			);
+		}
+		// 6. Else,
+		else {
+			// a. Let keysIter be ? GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]]).
+			var keysIter = GetIterator(
+				otherRec["[[SetObject]]"],
+				otherRec["[[Keys]]"]
+			);
+			// b. Let next be not-started.
+			var next;
+			// c. Repeat, while next is not done,
+			while (!keysIter["[[Done]]"]) {
+				// i. Set next to ? IteratorStepValue(keysIter).
+				next = IteratorStepValue(keysIter);
+				// ii. If next is not done, then
+				if (!keysIter["[[Done]]"]) {
+					// 1. Set next to CanonicalizeKeyedCollectionKey(next).
+					// eslint-disable-next-line no-compare-neg-zero
+					if (next === -0) next = 0;
+					// 2. Let inThis be SetDataHas(O.[[SetData]], next).
+					var inThis = O.has(next);
+					// 3. If inThis is true, then
+					if (inThis === true) {
+						// a. NOTE: Because other is an arbitrary object, it is possible for its "keys" iterator to produce the same value more than once.
+						// b. If SetDataHas(resultSetData, next) is false, then
+						if (result.has(next) === false) {
+							// i. Append next to resultSetData.
+							result.add(next);
+						}
+					}
+				}
+			}
+		}
+		// 7. Let result be OrdinaryObjectCreate(%Set.prototype%, « [[SetData]] »).
+		// 8. Set result.[[SetData]] to resultSetData.
+		// 9. Return result.
+		return result;
+	}
+);

--- a/polyfills/Set/prototype/intersection/tests.js
+++ b/polyfills/Set/prototype/intersection/tests.js
@@ -1,0 +1,43 @@
+/* global Set */
+
+it("is a function", function () {
+	proclaim.isFunction(Set.prototype.intersection);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Set.prototype.intersection, 1);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Set.prototype.intersection, "intersection");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Set.prototype, "intersection");
+});
+
+describe("intersection", function () {
+	it("should compute the intersection of a set with a smaller set", function () {
+		var set = new Set([1, 2, 3]).intersection(new Set([3, 4]));
+		proclaim.equal(set.size, 1);
+		proclaim.isTrue(set.has(3));
+	});
+
+	it("should compute the intersection of a set with a larger set", function () {
+		var set = new Set([3, 4]).intersection(new Set([1, 2, 3]));
+		proclaim.equal(set.size, 1);
+		proclaim.isTrue(set.has(3));
+	});
+
+	it("should throw for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Set.prototype.intersection.call({}, new Set());
+		}, TypeError);
+	});
+
+	it("should throw for an invalid `other`", function () {
+		proclaim.throws(function () {
+			Set.prototype.intersection.call(new Set(), {});
+		}, TypeError);
+	});
+});

--- a/polyfills/Set/prototype/isDisjointFrom/config.toml
+++ b/polyfills/Set/prototype/isDisjointFrom/config.toml
@@ -1,0 +1,31 @@
+aliases = [ "es2025" ]
+dependencies = [
+  "_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.GetIterator",
+	"_ESAbstract.GetSetRecord",
+	"_ESAbstract.IteratorClose",
+	"_ESAbstract.IteratorStepValue",
+	"_ESAbstract.NormalCompletion",
+	"_ESAbstract.ToBoolean",
+	"Set",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-set.prototype.isdisjointfrom"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/isDisjointFrom"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<122"
+edge = "*"
+firefox = "<127"
+firefox_mob = "<127"
+ie = "*"
+ie_mob = "*"
+opera = "<108"
+op_mob = "<81"
+op_mini = "*"
+safari = "<17.0"
+ios_saf = "<17.0"
+samsung_mob = "*"

--- a/polyfills/Set/prototype/isDisjointFrom/detect.js
+++ b/polyfills/Set/prototype/isDisjointFrom/detect.js
@@ -1,0 +1,2 @@
+/* global Set */
+"isDisjointFrom" in Set.prototype;

--- a/polyfills/Set/prototype/isDisjointFrom/polyfill.js
+++ b/polyfills/Set/prototype/isDisjointFrom/polyfill.js
@@ -1,0 +1,79 @@
+/* global Call, CreateMethodProperty, GetIterator, GetSetRecord, IteratorClose, IteratorStepValue, NormalCompletion, Set, ToBoolean */
+// 24.2.4.10 Set.prototype.isDisjointFrom ( other )
+CreateMethodProperty(
+	Set.prototype,
+	"isDisjointFrom",
+	function isDisjointFrom(other) {
+		// 1. Let O be the this value.
+		var O = this;
+		// 2. Perform ? RequireInternalSlot(O, [[SetData]]).
+		Set.prototype.has.call(O);
+		// 3. Let otherRec be ? GetSetRecord(other).
+		var otherRec = GetSetRecord(other);
+		// 4. If SetDataSize(O.[[SetData]]) ≤ otherRec.[[Size]], then
+		if (O.size <= otherRec["[[Size]]"]) {
+			// a. Let thisSize be the number of elements in O.[[SetData]].
+			var thisSize = O.size;
+			// b. Let index be 0.
+			var index = 0;
+			var earlyReturn = {};
+			try {
+				// c. Repeat, while index < thisSize,
+				O.forEach(
+					// i. Let e be O.[[SetData]][index].
+					function (e) {
+						if (index < thisSize) {
+							// ii. Set index to index + 1.
+							index = index + 1;
+							// iii. If e is not empty, then
+							// 1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
+							var inOther = ToBoolean(
+								Call(otherRec["[[Has]]"], otherRec["[[SetObject]]"], [e])
+							);
+							// 2. If inOther is true, return false.
+							if (inOther === true) {
+								// throw because we can't return from here
+								// it will be caught by the catch, below
+								throw earlyReturn;
+							}
+							// 3. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
+							// 4. Set thisSize to the number of elements in O.[[SetData]].
+							thisSize = O.size;
+						}
+					}
+				);
+			} catch (e) {
+				// handle special `throw earlyReturn` case, above
+				if (e === earlyReturn) return false;
+				throw e;
+			}
+		}
+		// 5. Else,
+		else {
+			// a. Let keysIter be ? GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]]).
+			var keysIter = GetIterator(
+				otherRec["[[SetObject]]"],
+				otherRec["[[Keys]]"]
+			);
+			// b. Let next be not-started.
+			var next;
+			// c. Repeat, while next is not done,
+			while (!keysIter["[[Done]]"]) {
+				// i. Set next to ? IteratorStepValue(keysIter).
+				next = IteratorStepValue(keysIter);
+				// ii. If next is not done, then
+				if (!keysIter["[[Done]]"]) {
+					// 1. If SetDataHas(O.[[SetData]], next) is true, then
+					if (O.has(next) === true) {
+						// a. Perform ? IteratorClose(keysIter, NormalCompletion(unused)).
+						IteratorClose(keysIter, NormalCompletion(undefined));
+						// b. Return false.
+						return false;
+					}
+				}
+			}
+		}
+		// 6. Return true.
+		return true;
+	}
+);

--- a/polyfills/Set/prototype/isDisjointFrom/tests.js
+++ b/polyfills/Set/prototype/isDisjointFrom/tests.js
@@ -1,0 +1,45 @@
+/* global Set */
+
+it("is a function", function () {
+	proclaim.isFunction(Set.prototype.isDisjointFrom);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Set.prototype.isDisjointFrom, 1);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Set.prototype.isDisjointFrom, "isDisjointFrom");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Set.prototype, "isDisjointFrom");
+});
+
+describe("isDisjointFrom", function () {
+	it("should compute whether a set is disjoint from a smaller set", function () {
+		proclaim.isTrue(new Set([1, 2, 3]).isDisjointFrom(new Set([4])));
+
+		proclaim.isFalse(new Set([1, 2, 3]).isDisjointFrom(new Set([1, 2])));
+		proclaim.isFalse(new Set([1, 2, 3]).isDisjointFrom(new Set([1, 4])));
+	});
+
+	it("should compute whether a set is disjoint from a larger set", function () {
+		proclaim.isTrue(new Set([4]).isDisjointFrom(new Set([1, 2, 3])));
+
+		proclaim.isFalse(new Set([1, 2]).isDisjointFrom(new Set([1, 2, 3])));
+		proclaim.isFalse(new Set([1, 4]).isDisjointFrom(new Set([1, 2, 3])));
+	});
+
+	it("should throw for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Set.prototype.isDisjointFrom.call({}, new Set());
+		}, TypeError);
+	});
+
+	it("should throw for an invalid `other`", function () {
+		proclaim.throws(function () {
+			Set.prototype.isDisjointFrom.call(new Set(), {});
+		}, TypeError);
+	});
+});

--- a/polyfills/Set/prototype/isSubsetOf/config.toml
+++ b/polyfills/Set/prototype/isSubsetOf/config.toml
@@ -1,0 +1,27 @@
+aliases = [ "es2025" ]
+dependencies = [
+  "_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.GetSetRecord",
+	"_ESAbstract.ToBoolean",
+	"Set",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-set.prototype.issubsetof"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/isSubsetOf"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<122"
+edge = "*"
+firefox = "<127"
+firefox_mob = "<127"
+ie = "*"
+ie_mob = "*"
+opera = "<108"
+op_mob = "<81"
+op_mini = "*"
+safari = "<17.0"
+ios_saf = "<17.0"
+samsung_mob = "*"

--- a/polyfills/Set/prototype/isSubsetOf/detect.js
+++ b/polyfills/Set/prototype/isSubsetOf/detect.js
@@ -1,0 +1,2 @@
+/* global Set */
+"isSubsetOf" in Set.prototype;

--- a/polyfills/Set/prototype/isSubsetOf/polyfill.js
+++ b/polyfills/Set/prototype/isSubsetOf/polyfill.js
@@ -1,0 +1,51 @@
+/* global Call, CreateMethodProperty, GetSetRecord, Set, ToBoolean */
+// 24.2.4.11 Set.prototype.isSubsetOf ( other )
+CreateMethodProperty(Set.prototype, "isSubsetOf", function isSubsetOf(other) {
+	// 1. Let O be the this value.
+	var O = this;
+	// 2. Perform ? RequireInternalSlot(O, [[SetData]]).
+	Set.prototype.has.call(O);
+	// 3. Let otherRec be ? GetSetRecord(other).
+	var otherRec = GetSetRecord(other);
+	// 4. If SetDataSize(O.[[SetData]]) > otherRec.[[Size]], return false.
+	if (O.size > otherRec["[[Size]]"]) {
+		return false;
+	}
+	// 5. Let thisSize be the number of elements in O.[[SetData]].
+	var thisSize = O.size;
+	// 6. Let index be 0.
+	var index = 0;
+	var earlyReturn = {};
+	try {
+		// 7. Repeat, while index < thisSize,
+		O.forEach(
+			// a. Let e be O.[[SetData]][index].
+			function (e) {
+				if (index < thisSize) {
+					// b. Set index to index + 1.
+					index = index + 1;
+					// c. If e is not empty, then
+					// i. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
+					var inOther = ToBoolean(
+						Call(otherRec["[[Has]]"], otherRec["[[SetObject]]"], [e])
+					);
+					// ii. If inOther is false, return false.
+					if (inOther === false) {
+						// throw because we can't return from here
+						// it will be caught by the catch, below
+						throw earlyReturn;
+					}
+					// iii. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
+					// iv. Set thisSize to the number of elements in O.[[SetData]].
+					thisSize = O.size;
+				}
+			}
+		);
+	} catch (e) {
+		// handle special `throw earlyReturn` case, above
+		if (e === earlyReturn) return false;
+		throw e;
+	}
+	// 8. Return true.
+	return true;
+});

--- a/polyfills/Set/prototype/isSubsetOf/tests.js
+++ b/polyfills/Set/prototype/isSubsetOf/tests.js
@@ -1,0 +1,38 @@
+/* global Set */
+
+it("is a function", function () {
+	proclaim.isFunction(Set.prototype.isSubsetOf);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Set.prototype.isSubsetOf, 1);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Set.prototype.isSubsetOf, "isSubsetOf");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Set.prototype, "isSubsetOf");
+});
+
+describe("isSubsetOf", function () {
+	it("should compute whether a set is a subset of another set", function () {
+		proclaim.isTrue(new Set([1, 2]).isSubsetOf(new Set([1, 2, 3])));
+
+		proclaim.isFalse(new Set([1, 2, 3]).isSubsetOf(new Set([2, 3])));
+		proclaim.isFalse(new Set([1, 2]).isSubsetOf(new Set([2, 3, 4])));
+	});
+
+	it("should throw for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Set.prototype.isSubsetOf.call({}, new Set());
+		}, TypeError);
+	});
+
+	it("should throw for an invalid `other`", function () {
+		proclaim.throws(function () {
+			Set.prototype.isSubsetOf.call(new Set(), {});
+		}, TypeError);
+	});
+});

--- a/polyfills/Set/prototype/isSupersetOf/config.toml
+++ b/polyfills/Set/prototype/isSupersetOf/config.toml
@@ -1,0 +1,29 @@
+aliases = [ "es2025" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.GetIterator",
+	"_ESAbstract.GetSetRecord",
+	"_ESAbstract.IteratorClose",
+	"_ESAbstract.IteratorStepValue",
+	"_ESAbstract.NormalCompletion",
+	"Set",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-set.prototype.issupersetof"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/isSupersetOf"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<122"
+edge = "*"
+firefox = "<127"
+firefox_mob = "<127"
+ie = "*"
+ie_mob = "*"
+opera = "<108"
+op_mob = "<81"
+op_mini = "*"
+safari = "<17.0"
+ios_saf = "<17.0"
+samsung_mob = "*"

--- a/polyfills/Set/prototype/isSupersetOf/detect.js
+++ b/polyfills/Set/prototype/isSupersetOf/detect.js
@@ -1,0 +1,2 @@
+/* global Set */
+"isSupersetOf" in Set.prototype;

--- a/polyfills/Set/prototype/isSupersetOf/polyfill.js
+++ b/polyfills/Set/prototype/isSupersetOf/polyfill.js
@@ -1,0 +1,39 @@
+/* global CreateMethodProperty, GetIterator, GetSetRecord, IteratorClose, IteratorStepValue, NormalCompletion, Set */
+// 24.2.4.12 Set.prototype.isSupersetOf ( other )
+CreateMethodProperty(
+	Set.prototype,
+	"isSupersetOf",
+	function isSupersetOf(other) {
+		// 1. Let O be the this value.
+		var O = this;
+		// 2. Perform ? RequireInternalSlot(O, [[SetData]]).
+		Set.prototype.has.call(O);
+		// 3. Let otherRec be ? GetSetRecord(other).
+		var otherRec = GetSetRecord(other);
+		// 4. If SetDataSize(O.[[SetData]]) < otherRec.[[Size]], return false.
+		if (O.size < otherRec["[[Size]]"]) {
+			return false;
+		}
+		// 5. Let keysIter be ? GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]]).
+		var keysIter = GetIterator(otherRec["[[SetObject]]"], otherRec["[[Keys]]"]);
+		// 6. Let next be not-started.
+		var next;
+		// 7. Repeat, while next is not done,
+		while (!keysIter["[[Done]]"]) {
+			// a. Set next to ? IteratorStepValue(keysIter).
+			next = IteratorStepValue(keysIter);
+			// b. If next is not done, then
+			if (!keysIter["[[Done]]"]) {
+				// i. If SetDataHas(O.[[SetData]], next) is false, then
+				if (O.has(next) === false) {
+					// 1. Perform ? IteratorClose(keysIter, NormalCompletion(unused)).
+					IteratorClose(keysIter, NormalCompletion(undefined));
+					// 2. Return false.
+					return false;
+				}
+			}
+		}
+		// 8. Return true.
+		return true;
+	}
+);

--- a/polyfills/Set/prototype/isSupersetOf/tests.js
+++ b/polyfills/Set/prototype/isSupersetOf/tests.js
@@ -1,0 +1,38 @@
+/* global Set */
+
+it("is a function", function () {
+	proclaim.isFunction(Set.prototype.isSupersetOf);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Set.prototype.isSupersetOf, 1);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Set.prototype.isSupersetOf, "isSupersetOf");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Set.prototype, "isSupersetOf");
+});
+
+describe("isSupersetOf", function () {
+	it("should compute whether a set is a superset of another set", function () {
+		proclaim.isTrue(new Set([1, 2, 3]).isSupersetOf(new Set([2, 3])));
+
+		proclaim.isFalse(new Set([1, 2]).isSupersetOf(new Set([1, 2, 3])));
+		proclaim.isFalse(new Set([2, 3, 4]).isSupersetOf(new Set([1, 2])));
+	});
+
+	it("should throw for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Set.prototype.isSupersetOf.call({}, new Set());
+		}, TypeError);
+	});
+
+	it("should throw for an invalid `other`", function () {
+		proclaim.throws(function () {
+			Set.prototype.isSupersetOf.call(new Set(), {});
+		}, TypeError);
+	});
+});

--- a/polyfills/Set/prototype/symmetricDifference/config.toml
+++ b/polyfills/Set/prototype/symmetricDifference/config.toml
@@ -1,0 +1,27 @@
+aliases = [ "es2025" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.GetIterator",
+	"_ESAbstract.GetSetRecord",
+	"_ESAbstract.IteratorStepValue",
+	"Set",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/symmetricDifference"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<122"
+edge = "*"
+firefox = "<127"
+firefox_mob = "<127"
+ie = "*"
+ie_mob = "*"
+opera = "<108"
+op_mob = "<81"
+op_mini = "*"
+safari = "<17.0"
+ios_saf = "<17.0"
+samsung_mob = "*"

--- a/polyfills/Set/prototype/symmetricDifference/detect.js
+++ b/polyfills/Set/prototype/symmetricDifference/detect.js
@@ -1,0 +1,2 @@
+/* global Set */
+"symmetricDifference" in Set.prototype;

--- a/polyfills/Set/prototype/symmetricDifference/polyfill.js
+++ b/polyfills/Set/prototype/symmetricDifference/polyfill.js
@@ -1,0 +1,55 @@
+/* global CreateMethodProperty, GetIterator, GetSetRecord, IteratorStepValue, Set */
+// 24.2.4.15 Set.prototype.symmetricDifference ( other )
+CreateMethodProperty(
+	Set.prototype,
+	"symmetricDifference",
+	function symmetricDifference(other) {
+		// 1. Let O be the this value.
+		var O = this;
+		// 2. Perform ? RequireInternalSlot(O, [[SetData]]).
+		Set.prototype.has.call(O);
+		// 3. Let otherRec be ? GetSetRecord(other).
+		var otherRec = GetSetRecord(other);
+		// 4. Let keysIter be ? GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]]).
+		var keysIter = GetIterator(otherRec["[[SetObject]]"], otherRec["[[Keys]]"]);
+		// 5. Let resultSetData be a copy of O.[[SetData]].
+		var result = new Set();
+		O.forEach(function (value) {
+			result.add(value);
+		});
+		// 6. Let next be not-started.
+		var next;
+		// 7. Repeat, while next is not done,
+		while (!keysIter["[[Done]]"]) {
+			// a. Set next to ? IteratorStepValue(keysIter).
+			next = IteratorStepValue(keysIter);
+			// b. If next is not done, then
+			if (!keysIter["[[Done]]"]) {
+				// i. Set next to CanonicalizeKeyedCollectionKey(next).
+				// eslint-disable-next-line no-compare-neg-zero
+				if (next === -0) next = 0;
+				// ii. Let resultIndex be SetDataIndex(resultSetData, next).
+				// iii. If resultIndex is not-found, let alreadyInResult be false. Otherwise let alreadyInResult be true.
+				var alreadyInResult = !result.has(next) ? false : true;
+				// iv. If SetDataHas(O.[[SetData]], next) is true, then
+				if (O.has(next) === true) {
+					// 1. If alreadyInResult is true, set resultSetData[resultIndex] to empty.
+					if (alreadyInResult === true) {
+						result.delete(next);
+					}
+				}
+				// v. Else,
+				else {
+					// 1. If alreadyInResult is false, append next to resultSetData.
+					if (alreadyInResult === false) {
+						result.add(next);
+					}
+				}
+			}
+		}
+		// 8. Let result be OrdinaryObjectCreate(%Set.prototype%, « [[SetData]] »).
+		// 9. Set result.[[SetData]] to resultSetData.
+		// 10. Return result.
+		return result;
+	}
+);

--- a/polyfills/Set/prototype/symmetricDifference/tests.js
+++ b/polyfills/Set/prototype/symmetricDifference/tests.js
@@ -1,0 +1,47 @@
+/* global Set */
+
+it("is a function", function () {
+	proclaim.isFunction(Set.prototype.symmetricDifference);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Set.prototype.symmetricDifference, 1);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Set.prototype.symmetricDifference, "symmetricDifference");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Set.prototype, "symmetricDifference");
+});
+
+describe("symmetricDifference", function () {
+	it("should compute the symmetric difference of a set with a smaller set", function () {
+		var set = new Set([1, 2, 3]).symmetricDifference(new Set([3, 4]));
+		proclaim.equal(set.size, 3);
+		proclaim.isTrue(set.has(1));
+		proclaim.isTrue(set.has(2));
+		proclaim.isTrue(set.has(4));
+	});
+
+	it("should compute the symmetric difference of a set with a larger set", function () {
+		var set = new Set([3, 4]).symmetricDifference(new Set([1, 2, 3]));
+		proclaim.equal(set.size, 3);
+		proclaim.isTrue(set.has(1));
+		proclaim.isTrue(set.has(2));
+		proclaim.isTrue(set.has(4));
+	});
+
+	it("should throw for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Set.prototype.symmetricDifference.call({}, new Set());
+		}, TypeError);
+	});
+
+	it("should throw for an invalid `other`", function () {
+		proclaim.throws(function () {
+			Set.prototype.symmetricDifference.call(new Set(), {});
+		}, TypeError);
+	});
+});

--- a/polyfills/Set/prototype/union/config.toml
+++ b/polyfills/Set/prototype/union/config.toml
@@ -1,0 +1,27 @@
+aliases = [ "es2025" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.GetIterator",
+	"_ESAbstract.GetSetRecord",
+	"_ESAbstract.IteratorStepValue",
+	"Set",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-set.prototype.union"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/union"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<122"
+edge = "*"
+firefox = "<127"
+firefox_mob = "<127"
+ie = "*"
+ie_mob = "*"
+opera = "<108"
+op_mob = "<81"
+op_mini = "*"
+safari = "<17.0"
+ios_saf = "<17.0"
+samsung_mob = "*"

--- a/polyfills/Set/prototype/union/detect.js
+++ b/polyfills/Set/prototype/union/detect.js
@@ -1,0 +1,2 @@
+/* global Set */
+"union" in Set.prototype;

--- a/polyfills/Set/prototype/union/polyfill.js
+++ b/polyfills/Set/prototype/union/polyfill.js
@@ -1,0 +1,39 @@
+/* global CreateMethodProperty, GetIterator, GetSetRecord, IteratorStepValue, Set */
+// 24.2.4.16 Set.prototype.union ( other )
+CreateMethodProperty(Set.prototype, "union", function union(other) {
+	// 1. Let O be the this value.
+	var O = this;
+	// 2. Perform ? RequireInternalSlot(O, [[SetData]]).
+	Set.prototype.has.call(O);
+	// 3. Let otherRec be ? GetSetRecord(other).
+	var otherRec = GetSetRecord(other);
+	// 4. Let keysIter be ? GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]]).
+	var keysIter = GetIterator(otherRec["[[SetObject]]"], otherRec["[[Keys]]"]);
+	// 5. Let resultSetData be a copy of O.[[SetData]].
+	var result = new Set();
+	O.forEach(function (value) {
+		result.add(value);
+	});
+	// 6. Let next be not-started.
+	var next;
+	// 7. Repeat, while next is not done,
+	while (!keysIter["[[Done]]"]) {
+		// a. Set next to ? IteratorStepValue(keysIter).
+		next = IteratorStepValue(keysIter);
+		// b. If next is not done, then
+		if (!keysIter["[[Done]]"]) {
+			// i. Set next to CanonicalizeKeyedCollectionKey(next).
+			// eslint-disable-next-line no-compare-neg-zero
+			if (next === -0) next = 0;
+			// ii. If SetDataHas(resultSetData, next) is false, then
+			if (result.has(next) === false) {
+				// 1. Append next to resultSetData.
+				result.add(next);
+			}
+		}
+	}
+	// 8. Let result be OrdinaryObjectCreate(%Set.prototype%, « [[SetData]] »).
+	// 9. Set result.[[SetData]] to resultSetData.
+	// 10. Return result.
+	return result;
+});

--- a/polyfills/Set/prototype/union/tests.js
+++ b/polyfills/Set/prototype/union/tests.js
@@ -1,0 +1,39 @@
+/* global Set */
+
+it("is a function", function () {
+	proclaim.isFunction(Set.prototype.union);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Set.prototype.union, 1);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Set.prototype.union, "union");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Set.prototype, "union");
+});
+
+describe("union", function () {
+	it("should compute the union of a set with another set", function () {
+		var set = new Set([1, 2]).union(new Set([2, 3]));
+		proclaim.equal(set.size, 3);
+		proclaim.isTrue(set.has(1));
+		proclaim.isTrue(set.has(2));
+		proclaim.isTrue(set.has(3));
+	});
+
+	it("should throw for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Set.prototype.union.call({}, new Set());
+		}, TypeError);
+	});
+
+	it("should throw for an invalid `other`", function () {
+		proclaim.throws(function () {
+			Set.prototype.union.call(new Set(), {});
+		}, TypeError);
+	});
+});

--- a/polyfills/_ESAbstract/GetSetRecord/config.toml
+++ b/polyfills/_ESAbstract/GetSetRecord/config.toml
@@ -1,0 +1,25 @@
+dependencies = [
+	"_ESAbstract.Get",
+	"_ESAbstract.IsCallable",
+	"_ESAbstract.ToIntegerOrInfinity",
+	"_ESAbstract.ToNumber",
+	"_ESAbstract.Type",
+]
+spec = "https://tc39.es/ecma262/#sec-getsetrecord"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+edge_mob = "*"
+firefox = "*"
+firefox_mob = "*"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "*"
+ios_saf = "*"
+samsung_mob = "*"

--- a/polyfills/_ESAbstract/GetSetRecord/polyfill.js
+++ b/polyfills/_ESAbstract/GetSetRecord/polyfill.js
@@ -1,0 +1,43 @@
+/* global Get, IsCallable, ToIntegerOrInfinity, ToNumber, Type */
+// 24.2.1.2 GetSetRecord ( obj )
+// eslint-disable-next-line no-unused-vars
+function GetSetRecord(obj) {
+	// 1. If obj is not an Object, throw a TypeError exception.
+	if (Type(obj) !== "object") {
+		throw new TypeError("argument must be an object");
+	}
+	// 2. Let rawSize be ? Get(obj, "size").
+	var rawSize = Get(obj, "size");
+	// 3. Let numSize be ? ToNumber(rawSize).
+	var numSize = ToNumber(rawSize);
+	// 4. NOTE: If rawSize is undefined, then numSize will be NaN.
+	// 5. If numSize is NaN, throw a TypeError exception.
+	if (isNaN(numSize)) {
+		throw new TypeError("size must be a number");
+	}
+	// 6. Let intSize be ! ToIntegerOrInfinity(numSize).
+	var intSize = ToIntegerOrInfinity(numSize);
+	// 7. If intSize < 0, throw a RangeError exception.
+	if (intSize < 0) {
+		throw new TypeError("size must be non-negative");
+	}
+	// 8. Let has be ? Get(obj, "has").
+	var has = Get(obj, "has");
+	// 9. If IsCallable(has) is false, throw a TypeError exception.
+	if (IsCallable(has) === false) {
+		throw new TypeError("has must be callable");
+	}
+	// 10. Let keys be ? Get(obj, "keys").
+	var keys = Get(obj, "keys");
+	// 11. If IsCallable(keys) is false, throw a TypeError exception.
+	if (IsCallable(keys) === false) {
+		throw new TypeError("keys must be callable");
+	}
+	// 12. Return a new Set Record { [[SetObject]]: obj, [[Size]]: intSize, [[Has]]: has, [[Keys]]: keys }.
+	return {
+		"[[SetObject]]": obj,
+		"[[Size]]": intSize,
+		"[[Has]]": has,
+		"[[Keys]]": keys
+	};
+}

--- a/polyfills/_ESAbstract/IteratorStepValue/config.toml
+++ b/polyfills/_ESAbstract/IteratorStepValue/config.toml
@@ -1,0 +1,19 @@
+dependencies = [ "_ESAbstract.IteratorStep", "_ESAbstract.IteratorValue" ]
+spec = "https://tc39.es/ecma262/#sec-iteratorstepvalue"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+edge_mob = "*"
+firefox = "*"
+firefox_mob = "*"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "*"
+ios_saf = "*"
+samsung_mob = "*"

--- a/polyfills/_ESAbstract/IteratorStepValue/polyfill.js
+++ b/polyfills/_ESAbstract/IteratorStepValue/polyfill.js
@@ -1,0 +1,25 @@
+/* global IteratorStep, IteratorValue */
+// 7.4.8 IteratorStepValue ( iteratorRecord )
+// eslint-disable-next-line no-unused-vars
+function IteratorStepValue(iteratorRecord) {
+	// 1. Let result be ? IteratorStep(iteratorRecord).
+	var result = IteratorStep(iteratorRecord);
+	// 2. If result is done, then
+	if (result === false) {
+		// a. Return done.
+		iteratorRecord["[[Done]]"] = true;
+		return;
+	}
+	// 3. Let value be Completion(IteratorValue(result)).
+	var value;
+	try {
+		value = IteratorValue(result);
+	} catch (err) {
+		// 4. If value is a throw completion, then
+		// a. Set iteratorRecord.[[Done]] to true.
+		iteratorRecord["[[Done]]"] = true;
+		throw err;
+	}
+	// 5. Return ? value.
+	return value;
+}


### PR DESCRIPTION
This PR adds the following ES2025 polyfills:
- `Set.prototype.difference(other)`
- `Set.prototype.intersection(other)`
- `Set.prototype.isDisjointFrom(other)`
- `Set.prototype.isSubsetOf(other)`
- `Set.prototype.isSupersetOf(other)`
- `Set.prototype.symmetricDifference(other)`
- `Set.prototype.union(other)`