### PR TITLE
pin polyfill dependencies in `package.json` files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6519,49 +6519,49 @@
       "name": "@mrhenry/polyfill-library--html5-elements",
       "version": "0.0.0",
       "devDependencies": {
-        "html5shiv": "^3.7.3"
+        "html5shiv": "3.7.3"
       }
     },
     "polyfills/AbortController": {
       "name": "@mrhenry/polyfill-library--abortcontroller",
       "version": "0.0.0",
       "devDependencies": {
-        "abort-controller": "^3.0.0"
+        "abort-controller": "3.0.0"
       }
     },
     "polyfills/ArrayBuffer": {
       "name": "@mrhenry/polyfill-library--arraybuffer",
       "version": "0.0.0",
       "devDependencies": {
-        "js-polyfills": "^0.1.40"
+        "js-polyfills": "0.1.43"
       }
     },
     "polyfills/atob": {
       "name": "@mrhenry/polyfill-library--atob",
       "version": "0.0.0",
       "devDependencies": {
-        "Base64": "^1.0.0"
+        "Base64": "1.3.0"
       }
     },
     "polyfills/AudioContext": {
       "name": "@mrhenry/polyfill-library--audiocontext",
       "version": "0.0.0",
       "devDependencies": {
-        "audio-context-polyfill": "^1.0.0"
+        "audio-context-polyfill": "1.0.0"
       }
     },
     "polyfills/HTMLPictureElement": {
       "name": "@mrhenry/polyfill-library--htmlpictureelement",
       "version": "0.0.0",
       "devDependencies": {
-        "picturefill": "^3.0.1"
+        "picturefill": "3.0.3"
       }
     },
     "polyfills/HTMLTemplateElement": {
       "name": "@mrhenry/polyfill-library--htmltemplateelement",
       "version": "0.0.0",
       "devDependencies": {
-        "@webcomponents/template": "^1.5.0"
+        "@webcomponents/template": "1.5.1"
       }
     },
     "polyfills/Intl": {
@@ -6573,7 +6573,7 @@
         "@formatjs/intl-getcanonicallocales": "1.6.0",
         "@formatjs/intl-listformat": "6.1.0",
         "@formatjs/intl-locale": "2.4.26",
-        "@formatjs/intl-localematcher": "^0.2.21",
+        "@formatjs/intl-localematcher": "0.2.32",
         "@formatjs/intl-numberformat": "7.1.0",
         "@formatjs/intl-pluralrules": "4.0.20",
         "@formatjs/intl-relativetimeformat": "9.1.0"
@@ -6583,14 +6583,14 @@
       "name": "@mrhenry/polyfill-library--mutationobserver",
       "version": "0.0.0",
       "devDependencies": {
-        "mutationobserver-shim": "^0.3.2"
+        "mutationobserver-shim": "0.3.7"
       }
     },
     "polyfills/ResizeObserver": {
       "name": "@mrhenry/polyfill-library--resizeobserver",
       "version": "0.0.0",
       "devDependencies": {
-        "@juggle/resize-observer": "^3.3.1"
+        "@juggle/resize-observer": "3.4.0"
       }
     },
     "polyfills/smoothscroll": {
@@ -6604,21 +6604,21 @@
       "name": "@mrhenry/polyfill-library--string-prototype-normalize",
       "version": "0.0.0",
       "devDependencies": {
-        "unorm": "^1.6.0"
+        "unorm": "1.6.0"
       }
     },
     "polyfills/UserTiming": {
       "name": "@mrhenry/polyfill-library--usertiming",
       "version": "0.0.0",
       "devDependencies": {
-        "usertiming": "^0.1.8"
+        "usertiming": "0.1.8"
       }
     },
     "polyfills/WebAnimations": {
       "name": "@mrhenry/polyfill-library--webanimations",
       "version": "0.0.0",
       "devDependencies": {
-        "web-animations-js": "^2.2.5"
+        "web-animations-js": "2.3.2"
       }
     }
   }

--- a/polyfills/AbortController/package.json
+++ b/polyfills/AbortController/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "abort-controller": "^3.0.0"
+    "abort-controller": "3.0.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/ArrayBuffer/package.json
+++ b/polyfills/ArrayBuffer/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "js-polyfills": "^0.1.40"
+    "js-polyfills": "0.1.43"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/AudioContext/package.json
+++ b/polyfills/AudioContext/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "audio-context-polyfill": "^1.0.0"
+    "audio-context-polyfill": "1.0.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/HTMLPictureElement/package.json
+++ b/polyfills/HTMLPictureElement/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "picturefill": "^3.0.1"
+    "picturefill": "3.0.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/HTMLTemplateElement/package.json
+++ b/polyfills/HTMLTemplateElement/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "@webcomponents/template": "^1.5.0"
+    "@webcomponents/template": "1.5.1"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/Intl/package.json
+++ b/polyfills/Intl/package.json
@@ -8,7 +8,7 @@
     "@formatjs/intl-getcanonicallocales": "1.6.0",
     "@formatjs/intl-listformat": "6.1.0",
     "@formatjs/intl-locale": "2.4.26",
-    "@formatjs/intl-localematcher": "^0.2.21",
+    "@formatjs/intl-localematcher": "0.2.32",
     "@formatjs/intl-numberformat": "7.1.0",
     "@formatjs/intl-pluralrules": "4.0.20",
     "@formatjs/intl-relativetimeformat": "9.1.0"

--- a/polyfills/MutationObserver/package.json
+++ b/polyfills/MutationObserver/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "mutationobserver-shim": "^0.3.2"
+    "mutationobserver-shim": "0.3.7"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/ResizeObserver/package.json
+++ b/polyfills/ResizeObserver/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "@juggle/resize-observer": "^3.3.1"
+    "@juggle/resize-observer": "3.4.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/String/prototype/normalize/package.json
+++ b/polyfills/String/prototype/normalize/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "unorm": "^1.6.0"
+    "unorm": "1.6.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/UserTiming/package.json
+++ b/polyfills/UserTiming/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "usertiming": "^0.1.8"
+    "usertiming": "0.1.8"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/WebAnimations/package.json
+++ b/polyfills/WebAnimations/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "web-animations-js": "^2.2.5"
+    "web-animations-js": "2.3.2"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/atob/package.json
+++ b/polyfills/atob/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "Base64": "^1.0.0"
+    "Base64": "1.3.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/polyfills/~html5-elements/package.json
+++ b/polyfills/~html5-elements/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "html5shiv": "^3.7.3"
+    "html5shiv": "3.7.3"
   },
   "volta": {
     "extends": "../../package.json"


### PR DESCRIPTION
This doesn't change any of the actual versions of polyfill packages.
Pinning the versions also isn't new, we have lock files.

It only changes how the version was described in `package.json` files.

------

This is intended to make it easier to update other packages with commands like `npm update`.
Running `npm update` will no longer affect polyfill package versions.

----

This adds a little bit of hardening against malicious changes in polyfills upstream.

Updating polyfill versions is still fine but should always be done separately from updating other dependencies.