### PR TITLE
update CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,9 @@ on:
   merge_group:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
     security-events: write
@@ -43,7 +46,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         cache: 'npm'
 
     - run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/test-polyfills-exhaustive.yml
+++ b/.github/workflows/test-polyfills-exhaustive.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: env

--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -44,7 +44,7 @@ jobs:
     # <insert integration tests needing secrets>
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         cache: 'npm'
 
     - name: env

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,13 +5,17 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,6 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         node: [18, 20, 22]
+        include:
+        - node: 18
+          older_node_version: true
+        - node: 20
+          older_node_version: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,4 +24,9 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+
+      - run: npm run test-older-node
+        if: ${{ (matrix.older_node_version) }}
+
       - run: npm run test
+        if: ${{ !(matrix.older_node_version) }}

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "build": "npm run clean && node tasks/updatesources && node tasks/buildsources/buildsources",
     "watch": "npm run clean && node tasks/updatesources && node tasks/buildsources/watchsource",
     "fmt": "eslint . --fix",
-    "test-end-to-end": "node --test test/end-to-end",
-    "test-node": "node --test test/node",
-    "test-unit": "node --test test/unit",
-    "test": "node --test test/unit && node --test test/node && node --test test/end-to-end",
+    "test-end-to-end": "node --test 'test/end-to-end/**/*.test.js'",
+    "test-node": "node --test 'test/node/**/*.test.js'",
+    "test-unit": "node --test 'test/unit/**/*.test.js'",
+    "test": "node --test 'test/unit/**/*.test.js' && node --test 'test/node/**/*.test.js' && node --test 'test/end-to-end/**/*.test.js'",
+    "test-older-node": "node --test 'test/unit' && node --test 'test/node' && node --test 'test/end-to-end'",
     "prepublishOnly": "npm run build",
     "create-new-polyfill": "node ./tasks/create-new-polyfill.js",
     "update-browserstack-list": "node ./tasks/updatebrowserstacklist.js"
@@ -68,6 +69,6 @@
     "webdriverio": "^8.0.0"
   },
   "volta": {
-    "node": "20.11.1"
+    "node": "22.3.0"
   }
 }

--- a/polyfills/Event/scrollend/polyfill.test.js
+++ b/polyfills/Event/scrollend/polyfill.test.js
@@ -1,4 +1,8 @@
 describe('Event.scrollend', function () {
+	// Scrolling and scroll events can be flaky in headless mode.
+	// CI environments are often headless.
+	this.retries(3);
+
 	var el;
 
 	before(function () {


### PR DESCRIPTION
- use node 22 as the primary version
- also have some lib tests with node 18 and node 20 (LTS versions)
- make tests less flaky for `Event.scrollend`