### PR TITLE
Fixes `require.resolve` with `paths` property

### DIFF
--- a/tasks/updatesources.js
+++ b/tasks/updatesources.js
@@ -17,7 +17,7 @@ const installPolyfill = config => {
 	const polyfillOutputPath = path.join(polyfillOutputFolder, 'polyfill.js');
 
 	const polyfillSourcePaths = (config.install.paths || ['']).map((p) => {
-		return require.resolve(path.join(config.install.module, p), [polyfillOutputFolder])
+		return require.resolve(path.join(config.install.module, p), { paths: [polyfillOutputFolder] })
 	});
 
 	const newPolyfill = loadSource(polyfillSourcePaths);


### PR DESCRIPTION
This PR fixes the `require.resolve` call that was introduced in https://github.com/mrhenry/polyfill-library/pull/17; the `options` argument should be an object.

Resolves https://github.com/mrhenry/polyfill-library/issues/55.