### PR TITLE
Fixes `Reflect.defineProperty` property name mismatch

### DIFF
--- a/polyfills/Reflect/defineProperty/polyfill.js
+++ b/polyfills/Reflect/defineProperty/polyfill.js
@@ -11,7 +11,22 @@ CreateMethodProperty(Reflect, 'defineProperty', function defineProperty(target, 
 	var desc = ToPropertyDescriptor(attributes);
 	// 4. Return ? target.[[DefineOwnProperty]](key, desc).
 	try {
-		Object.defineProperty(target, key, desc);
+		var newDesc = {};
+		var props = [
+			["[[Value]]", "value"],
+			["[[Get]]", "get"],
+			["[[Set]]", "set"],
+			["[[Writable]]", "writable"],
+			["[[Enumerable]]", "enumerable"],
+			["[[Configurable]]", "configurable"]
+		];
+		for (var i = 0; i < props.length; i++) {
+			var prop = props[i];
+			if (prop[0] in desc) {
+				newDesc[prop[1]] = desc[prop[0]];
+			}
+		}
+		Object.defineProperty(target, key, newDesc);
 		return true;
 	} catch (e) {
 		return false;

--- a/polyfills/Reflect/defineProperty/polyfill.test.js
+++ b/polyfills/Reflect/defineProperty/polyfill.test.js
@@ -19,8 +19,9 @@ it('is not enumerable', function () {
 
 it('returns true if defining the property was a success', function () {
 	var o = {};
-	proclaim.isTrue(Reflect.defineProperty(o, 'a', {}));
+	proclaim.isTrue(Reflect.defineProperty(o, 'a', { value: 'hi' }));
 	proclaim.isTrue(Object.prototype.hasOwnProperty.call(o, 'a'));
+	proclaim.equal(o.a, 'hi');
 });
 
 if ('freeze' in Object && (function () {


### PR DESCRIPTION
This PR fixes the `Reflect.defineProperty` polyfill, which uses the result of the `ToPropertyDescriptor` abstract operation incorrectly.