### PR TITLE
Fixes `ArrayBuffer` and `TypedArray.prototype.@@iterator` detection in IE11

### DIFF
--- a/polyfills/ArrayBuffer/detect.js
+++ b/polyfills/ArrayBuffer/detect.js
@@ -1,5 +1,7 @@
 // use "Int8Array" as a proxy for support of "TypedArray" subclasses
 // confirm that the prototype of "Int8Array" is NOT the "Object" prototype, which is a bug in IE11 and maybe other old browsers
 'ArrayBuffer' in self && 'DataView' in self && 'Int8Array' in self
+// IE11 has an incomplete implementation that's missing `slice` and maybe others
+&& 'slice' in self.Int8Array.prototype
 // TODO: add back this check once we remove support for ie10 and below
 // && Object.getPrototypeOf(self.Int8Array) !== Object.getPrototypeOf(Object)

--- a/polyfills/TypedArray/prototype/@@iterator/detect.js
+++ b/polyfills/TypedArray/prototype/@@iterator/detect.js
@@ -1,2 +1,2 @@
 // use "Int8Array" as a proxy for support of "TypedArray" subclasses
-'Symbol' in self && 'iterator' in self.Symbol && 'Int8Array' in self && self.Symbol.iterator in self.Int8Array.prototype
+'Symbol' in self && 'iterator' in self.Symbol && 'Int8Array' in self && self.Symbol.iterator in self.Int8Array.prototype && self.Int8Array.prototype[self.Symbol.iterator] !== undefined

--- a/polyfills/TypedArray/prototype/@@iterator/polyfill.test.js
+++ b/polyfills/TypedArray/prototype/@@iterator/polyfill.test.js
@@ -4,8 +4,10 @@
 
 it('is an alias to %TypedArray%.prototype.values', function () {
 	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.isDefined(Int8Array.prototype.__proto__[Symbol.iterator]);
 		proclaim.deepEqual(Int8Array.prototype.__proto__[Symbol.iterator], Int8Array.prototype.__proto__.values);
 	} else {
+		proclaim.isDefined(Int8Array.prototype[Symbol.iterator]);
 		proclaim.deepEqual(Int8Array.prototype[Symbol.iterator], Int8Array.prototype.values);
 	}
 });


### PR DESCRIPTION
This PR fixes `ArrayBuffer` and `TypedArray.prototype.@@iterator` detection; these are being incorrectly detected as present in IE11.