### PR TITLE
Improves stable sort detection in `Array.prototype.sort`

### DIFF
--- a/polyfills/Array/prototype/sort/detect.js
+++ b/polyfills/Array/prototype/sort/detect.js
@@ -1,5 +1,29 @@
 'sort' in Array.prototype && (function() {
 	// Check it does a stable sort
-	var obj = {length:3, 0:2, 1:1,2:3};
-	return Array.prototype.sort.call(obj, function(a,b) {return a-b}) === obj;
+	var arr = [
+		["z", "z"],
+		["a", "a"],
+		["z", "y"],
+		["a", "b"],
+		["z", "x"],
+		["a", "c"],
+		["z", "w"],
+		["a", "d"],
+		["z", "v"],
+		["a", "e"],
+		["z", "u"],
+		["a", "f"],
+		["z", "t"],
+		["a", "h"]
+	];
+	arr.sort(function (a, b) {
+		if (a[0] < b[0]) {
+			return -1;
+		}
+		if (a[0] > b[0]) {
+			return 1;
+		}
+		return 0;
+	});
+	return arr[0][1] === "a";
 }())


### PR DESCRIPTION
This PR improves stable sort detection in `Array.prototype.sort`; currently, it does not properly check stable sorting of arrays that contain duplicate values.