### PR TITLE
Fixes github actions dist cache key

### DIFF
--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--${{ env.commit-sha }}
 
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR puts back `env.commit-sha` in Github Actions, which seems to have been inadvertently changed (in https://github.com/mrhenry/polyfill-library/pull/39/files#diff-765809e3c0b1f9439625007384022dd3e6d70070bed6898f3a00fa3371d6c89fR60) to `env.GITHUB_SHA`, which doesn't exist.