### PR TITLE
Pins `node` to 22.4.1 temporarily

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 22.4.1
         cache: 'npm'
 
     - run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.4.1
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/test-polyfills-exhaustive.yml
+++ b/.github/workflows/test-polyfills-exhaustive.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.4.1
           cache: 'npm'
 
       - name: env

--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -44,7 +44,7 @@ jobs:
     # <insert integration tests needing secrets>
     - uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 22.4.1
         cache: 'npm'
 
     - name: env


### PR DESCRIPTION
This PR updates Github Actions to use Node.js 22.4.1 temporarily, until https://github.com/nodejs/node/issues/53902 is fixed.