### PR TITLE
Improves `URL` polyfill to work without `TypedArray.prototype.slice/indexOf`

### DIFF
--- a/polyfills/ArrayBuffer/config.toml
+++ b/polyfills/ArrayBuffer/config.toml
@@ -17,7 +17,7 @@ docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global
 [browsers]
 android = "*"
 bb = "*"
-chrome = "<45"
+chrome = "<32"
 edge = "<14"
 edge_mob = "<14"
 firefox = "<44"
@@ -27,8 +27,8 @@ ie_mob = "*"
 opera = "<19"
 op_mob = "<19"
 op_mini = "*"
-safari = "<10.0"
-ios_saf = "<10.0"
+safari = "<7.0"
+ios_saf = "<7.0"
 samsung_mob = "<2.0"
 
 [install]

--- a/polyfills/ArrayBuffer/detect.js
+++ b/polyfills/ArrayBuffer/detect.js
@@ -1,7 +1,5 @@
 // use "Int8Array" as a proxy for support of "TypedArray" subclasses
 // confirm that the prototype of "Int8Array" is NOT the "Object" prototype, which is a bug in IE11 and maybe other old browsers
 'ArrayBuffer' in self && 'DataView' in self && 'Int8Array' in self
-// IE11 has an incomplete implementation that's missing `slice` and maybe others
-&& 'slice' in self.Int8Array.prototype
 // TODO: add back this check once we remove support for ie10 and below
 // && Object.getPrototypeOf(self.Int8Array) !== Object.getPrototypeOf(Object)

--- a/polyfills/URL/polyfill.js
+++ b/polyfills/URL/polyfill.js
@@ -2498,7 +2498,7 @@ function percentDecodeBytes(input) {
       i += 2;
     }
   }
-  return output.slice(0, outputIndex);
+  return output.subarray(0, outputIndex);
 }
 
 // https://url.spec.whatwg.org/#string-percent-decode
@@ -3739,10 +3739,10 @@ function parseUrlencoded(input) {
       }
       var name = void 0,
         value = void 0;
-      var indexOfEqual = bytes.indexOf(p("="));
+      var indexOfEqual = Array.prototype.indexOf.call(bytes, p("="));
       if (indexOfEqual >= 0) {
-        name = bytes.slice(0, indexOfEqual);
-        value = bytes.slice(indexOfEqual + 1);
+        name = bytes.subarray(0, indexOfEqual);
+        value = bytes.subarray(indexOfEqual + 1);
       } else {
         name = bytes;
         value = new Uint8Array(0);
@@ -3810,22 +3810,22 @@ function serializeUrlencoded(tuples) {
 function strictlySplitByteSequence(buf, cp) {
   var list = [];
   var last = 0;
-  var i = buf.indexOf(cp);
+  var i = Array.prototype.indexOf.call(buf, cp);
   while (i >= 0) {
-    list.push(buf.slice(last, i));
+    list.push(buf.subarray(last, i));
     last = i + 1;
-    i = buf.indexOf(cp, last);
+    i = Array.prototype.indexOf.call(buf, cp, last);
   }
   if (last !== buf.length) {
-    list.push(buf.slice(last));
+    list.push(buf.subarray(last));
   }
   return list;
 }
 function replaceByteInByteSequence(buf, from, to) {
-  var i = buf.indexOf(from);
+  var i = Array.prototype.indexOf.call(buf, from);
   while (i >= 0) {
     buf[i] = to;
-    i = buf.indexOf(from, i + 1);
+    i = Array.prototype.indexOf.call(buf, from, i + 1);
   }
   return buf;
 }

--- a/polyfills/URL/update.task.js
+++ b/polyfills/URL/update.task.js
@@ -47,6 +47,26 @@ const codeProcessors = [
 			)
 	},
 	{
+		filename: "node_modules/whatwg-url/lib/percent-encoding.js",
+		description: "replace `typedArray.slice` with `typedArray.subarray`",
+		processor: (code) =>
+			code.replace(
+				/return output\.slice\(0, outputIndex\);/,
+				"return output.subarray(0, outputIndex);"
+			)
+	},
+	{
+		filename: "node_modules/whatwg-url/lib/urlencoded.js",
+		description:
+			"replace `typedArray.slice` with `typedArray.subarray` and `typedArray.indexOf` with `Array.prototype.indexOf`",
+		processor: (code) =>
+			code
+				.replace(/bytes\.slice\(/g, "bytes.subarray(")
+				.replace(/buf\.slice\(/g, "buf.subarray(")
+				.replace(/bytes\.indexOf\(/g, "Array.prototype.indexOf.call(bytes, ")
+				.replace(/buf\.indexOf\(/g, "Array.prototype.indexOf.call(buf, ")
+	},
+	{
 		filename: "node_modules/whatwg-url/lib/URL.js",
 		description:
 			"delete `URL.prototype.toJSON`, `URL.canParse`, and `URL.parse`, since they should come from other polyfills",


### PR DESCRIPTION
This PR updates the `URL` polyfill to not depend on `TypedArray.prototype.slice` or `TypedArray.prototype.indexOf`, which may not be available in all engines. It also reverts changes to the `ArrayBuffer` polyfill from https://github.com/mrhenry/polyfill-library/pull/62 to avoid loading the entire `ArrayBuffer` polyfill in engines that don't need it.