### PR TITLE
Bumps `webdriverio` to latest, adds `isRetryableError` utility, reduces test flakiness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "semver": "^7.3.7",
         "toposort": "^2.0.2",
         "typescript": "^5.6.2",
+        "ua-parser-js": "^2.0.0",
         "uglify-js": "^3.17.4",
         "webdriverio": "^9.1.4"
       },
@@ -4831,6 +4832,27 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/detective": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
@@ -7311,6 +7333,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -10703,6 +10746,59 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.0.tgz",
+      "integrity": "sha512-SASgD4RlB7+SCMmlVNqrhPw0f/2pGawWBzJ2+LwGTD0GgNnrKGzPJDiraGHJDwW9Zm5DH2lTmUpqDpbZjJY4+Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11148,6 +11148,16 @@
         }
       }
     },
+    "node_modules/webdriverio/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/webdriverio/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,15 +2654,15 @@
       }
     },
     "node_modules/@wdio/config": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.1.3.tgz",
-      "integrity": "sha512-fozjb5Jl26QqQoZ2lJc8uZwzK2iKKmIfNIdNvx5JmQt78ybShiPuWWgu/EcHYDvAiZwH76K59R1Gp4lNmmEDew==",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.2.8.tgz",
+      "integrity": "sha512-EGMmBPGJbz6RmgMjebRWkWu3fGyeTIRcusF4UA4f2tiUEKY8nbzUO/ZyDjVQNR+YVB40q0jcqAqpszYRrIzzeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@wdio/logger": "9.1.3",
-        "@wdio/types": "9.1.3",
-        "@wdio/utils": "9.1.3",
+        "@wdio/types": "9.2.2",
+        "@wdio/utils": "9.2.8",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
@@ -2778,9 +2778,9 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.0.8.tgz",
-      "integrity": "sha512-xRH54byFf623/w/KW62xkf/C2mGyigSfMm+UT3tNEAd5ZA9X2VAWQWQBPzdcrsck7Fxk4zlQX8Kb34RSs7Cy4Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.2.2.tgz",
+      "integrity": "sha512-0GMUSHCbYm+J+rnRU6XPtaUgVCRICsiH6W5zCXpePm3wLlbmg/mvZ+4OnNErssbpIOulZuAmC2jNmut2AEfWSw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2798,9 +2798,9 @@
       }
     },
     "node_modules/@wdio/types": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.1.3.tgz",
-      "integrity": "sha512-oQrzLQBqn/+HXSJJo01NEfeKhzwuDdic7L8PDNxv5ySKezvmLDYVboQfoSDRtpAdfAZCcxuU9L4Jw7iTf6WV3g==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.2.2.tgz",
+      "integrity": "sha512-nHZ9Ne9iRQFJ1TOYKUn4Fza69IshTTzk6RYmSZ51ImGs9uMZu0+S0Jm9REdly+VLN3FzxG6g2QSe0/F3uNVPdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2811,15 +2811,15 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.1.3.tgz",
-      "integrity": "sha512-dYeOzq9MTh8jYRZhzo/DYyn+cKrhw7h0/5hgyXkbyk/wHwF/uLjhATPmfaCr9+MARSEdiF7wwU8iRy/V0jfsLg==",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.2.8.tgz",
+      "integrity": "sha512-rKm5FXkpsCyeqh8tdirtRUHvgNytWNMiaVKdctsvKOJvqnDVPAAQcz9Wmgo7bSwoLwtSHcDaRoxY7olV7J4QnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
         "@wdio/logger": "9.1.3",
-        "@wdio/types": "9.1.3",
+        "@wdio/types": "9.2.2",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
         "edgedriver": "^5.6.1",
@@ -10798,9 +10798,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
-      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11080,20 +11080,21 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.1.3.tgz",
-      "integrity": "sha512-DXt9az2BdWZmqxRZOfzW9fdpVGTdU7pEgkf9a/hpllF4DmCINvLmnZxOoqn2apIec+irRXCSlLUcf8XFSlmYlw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.4.1.tgz",
+      "integrity": "sha512-vFDdxMj/9W1+6jhpHSiRYfO8dix23HjAUtLx7aOv9ejEsntC0EzCIAftJ59YsF3Ppu184+FkdDVhnivpkZPTFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.1.3",
+        "@wdio/config": "9.2.8",
         "@wdio/logger": "9.1.3",
-        "@wdio/protocols": "9.0.8",
-        "@wdio/types": "9.1.3",
-        "@wdio/utils": "9.1.3",
+        "@wdio/protocols": "9.2.2",
+        "@wdio/types": "9.2.2",
+        "@wdio/utils": "9.2.8",
         "deepmerge-ts": "^7.0.3",
+        "undici": "^6.20.1",
         "ws": "^8.8.0"
       },
       "engines": {
@@ -11101,20 +11102,20 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.1.4.tgz",
-      "integrity": "sha512-uW6nj/+zSaTAhbEP88tHHOzcYOYRe+vfSpR7F1O0HXvWI+PfcQUDA8GE48TXpjDawRcKdOYMmZIzNNjn09ttSw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.4.1.tgz",
+      "integrity": "sha512-XIPtRnxSES4CoxH2BfUY/6QzNgEgJEUjMYu7t7SJR8bVfbLRVXAA1ie9kM0MtdLs4oZ2Pr8rR8fqytsA1CjEWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.1.3",
+        "@wdio/config": "9.2.8",
         "@wdio/logger": "9.1.3",
-        "@wdio/protocols": "9.0.8",
+        "@wdio/protocols": "9.2.2",
         "@wdio/repl": "9.0.8",
-        "@wdio/types": "9.1.3",
-        "@wdio/utils": "9.1.3",
+        "@wdio/types": "9.2.2",
+        "@wdio/utils": "9.2.8",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
@@ -11133,7 +11134,7 @@
         "rgb2hex": "0.2.5",
         "serialize-error": "^11.0.3",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.1.3"
+        "webdriver": "9.4.1"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -11145,16 +11146,6 @@
         "puppeteer-core": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webdriverio/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/webdriverio/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "semver": "^7.3.7",
     "toposort": "^2.0.2",
     "typescript": "^5.6.2",
+    "ua-parser-js": "^2.0.0",
     "uglify-js": "^3.17.4",
     "webdriverio": "^9.1.4"
   },

--- a/test/polyfills/remotetest.js
+++ b/test/polyfills/remotetest.js
@@ -355,14 +355,7 @@ async function main() {
 								return job;
 							})
 							.catch(error => {
-								if (error.message.includes("There was an error. Please try again.")) {
-									/*
-										This is an exception that Browserstack is throwing when it
-										fails to open a session using a real device. I think that
-										there aren't real devices available.
-										We need to wait some time to try again because it depends on time.
-										We will also try more for these exceptions.
-									*/
+								if (TestJob.isRetryableError(error)) {
 									return wait(30 * 1000).then(() =>
 										job
 											.run()

--- a/test/polyfills/remotetest.js
+++ b/test/polyfills/remotetest.js
@@ -174,11 +174,6 @@ async function main() {
 	const includePolyfills = "includePolyfills=" + (mode === "control" ? "no" : "yes");
 	// https://www.browserstack.com/question/759
 	const url = `http://bs-local.com:9876/${director ? '' : 'test'}?${includePolyfills}&${always}${feature}`;
-	const tunnelId =
-		"build:" +
-		(process.env.CIRCLE_BUILD_NUM || process.env.NODE_ENV || "null") +
-		"_" +
-		new Date().toISOString();
 
 	const jobConfigs = browsers.flatMap(browser => {
 		let configs = [];
@@ -189,7 +184,7 @@ async function main() {
 		};
 
 		if (
-			(browser === 'ie/8.0' || browser === 'ie/9.0') &&
+			(browser === 'ie/8.0' || browser === 'ie/9.0' || browser === 'ie/10.0' || browser.startsWith('ios/11')) &&
 			modified.testEverything // no need to shard tests if only a subset is tested
 		) {
 			configs = [
@@ -238,7 +233,7 @@ async function main() {
 			url,
 			mode,
 			jobConfig.capability,
-			tunnelId,
+			`Polyfill Library: ${jobConfig.browser} - ${jobConfig.polyfillCombinations ? 'interop' : 'individual'} - ${jobConfig.shard || '1'} - ${new Date().toISOString()}`,
 			testBrowserTimeout,
 			pollTick,
 			jobConfig.polyfillCombinations,

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -8,8 +8,7 @@ const promisify = require("node:util").promisify;
 const readFile = promisify(fs.readFile);
 const path = require("node:path");
 const handlebars = require("handlebars");
-const UA = require("@financial-times/polyfill-useragent-normaliser");
-const normalizeUserAgent = UA.normalize;
+const ua_parser = require('./ua-parser');
 
 process.title = "polyfill-library-test-server";
 
@@ -57,7 +56,7 @@ const cacheFor1Day = cache("1 day", () => true, {
 			request.query.always;
 		if (request.query.always === "no") {
 			const ua = request.get("User-Agent");
-			key += normalizeUserAgent(ua);
+			key += ua_parser(ua).normalize();
 		}
 		return key;
 	}
@@ -114,7 +113,7 @@ app.get(
 				),
 				minify: false,
 				stream: false,
-				ua: always === "yes" ? new UA("other/0.0.0") : new UA(request.get("user-agent"))
+				ua: ua_parser(always === "yes" ? "other/0.0.0" : request.get("user-agent"))
 			};
 
 			const bundle = await polyfillio.getPolyfillString(parameters);
@@ -246,7 +245,7 @@ function createEndpoint(template) {
 		}
 		let polyfills;
 		if (includePolyfills === 'yes' && always === 'no') {
-			polyfills = await testablePolyfills(normalizeUserAgent(ua));
+			polyfills = await testablePolyfills(ua_parser(ua).normalize());
 		} else {
 			polyfills = await testablePolyfills();
 		}

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -171,7 +171,10 @@ module.exports = class TestJob {
 	static isRetryableError(error) {
 		return (
 			error.message.includes("There was an error. Please try again.") ||
-			error.message.includes("Failed to create session.")
+			error.message.includes("Failed to create session.") ||
+			error.message.includes(
+				"An unknown server-side error occurred while processing the command."
+			)
 		);
 	}
 

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -174,6 +174,9 @@ module.exports = class TestJob {
 			error.message.includes("Failed to create session.") ||
 			error.message.includes(
 				"An unknown server-side error occurred while processing the command."
+			) ||
+			error.message.includes(
+				'The operation was aborted due to timeout when running "execute/sync" with method "POST"'
 			)
 		);
 	}

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -115,7 +115,11 @@ module.exports = class TestJob {
 				We need to wait some time to try again because it depends on time.
 				We will also try more for these exceptions.
 			*/
-			if (error.message.includes("There was an error. Please try again.") && this.runCount < 3) {
+			if (
+				(error.message.includes("There was an error. Please try again.") ||
+					error.message.includes("Failed to create session.")) &&
+				this.runCount < 3
+			) {
 				this.runCount += 1;
 				this.setState("waiting 30 seconds to retry");
 				await wait(30 * 1000);

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -108,18 +108,7 @@ module.exports = class TestJob {
 				key: process.env.BROWSERSTACK_ACCESS_KEY
 			});
 		} catch (error) {
-			/*
-				This is an exception that Browserstack is throwing when it
-				fails to open a session using a real device. I think that
-				there aren't real devices available.
-				We need to wait some time to try again because it depends on time.
-				We will also try more for these exceptions.
-			*/
-			if (
-				(error.message.includes("There was an error. Please try again.") ||
-					error.message.includes("Failed to create session.")) &&
-				this.runCount < 3
-			) {
+			if (TestJob.isRetryableError(error) && this.runCount < 3) {
 				this.runCount += 1;
 				this.setState("waiting 30 seconds to retry");
 				await wait(30 * 1000);
@@ -177,6 +166,13 @@ module.exports = class TestJob {
 			this.setState("error");
 			throw error;
 		}
+	}
+
+	static isRetryableError(error) {
+		return (
+			error.message.includes("There was an error. Please try again.") ||
+			error.message.includes("Failed to create session.")
+		);
 	}
 
 	setState(newState) {

--- a/test/polyfills/ua-parser.js
+++ b/test/polyfills/ua-parser.js
@@ -1,0 +1,62 @@
+const semver = require('semver');
+const uap = require('ua-parser-js');
+
+/**
+ * @param {string} ua
+ * @returns {import('../../lib/index').UaParser}
+ */
+function ua_parser(ua) {
+	const p = uap(ua);
+
+	return {
+		normalize: function normalize() {
+			return this.getFamily() + "/" + this.getVersion();
+		},
+		isUnknown: function isUnknown() {
+			return !p.browser.name || !p.browser.version || this.getFamily() === 'other';
+		},
+		getVersion: function getVersion() {
+			if (this.isUnknown()) return '0.0.0';
+
+			if (this.getFamily() === 'ios_saf' && p.os.version) return semver.coerce(p.os.version).toString();
+
+			return semver.coerce(p.browser.version).toString();
+		},
+		getFamily: function getFamily() {
+			switch (p.browser.name) {
+				case "Android Browser":
+					return "android"
+				case "Chrome":
+				case "Chrome Mobile":
+				case "Chrome Headless":
+				case "Chrome WebView":
+				case "Chromium":
+					return "chrome"
+				case "Edge":
+					if (semver.satisfies(semver.coerce(p.browser.version), '>= 79')) return 'chrome';
+
+					return "edge";
+				case "Firefox":
+					return "firefox";
+				case "Firefox Mobile":
+					return "firefox_mob";
+				case "IE":
+					return "ie";
+				case "IEMobile":
+					return "ie_mob";
+				case "Safari":
+					return "safari";
+				case "Mobile Safari":
+				case "Safari Mobile":
+					return "ios_saf";
+				default:
+					return "other";
+			}
+		},
+		satisfies: function satisfies(range) {
+			return semver.satisfies(this.getVersion(), range);
+		}
+	}
+}
+
+module.exports = ua_parser;


### PR DESCRIPTION
This PR bumps `webdriverio` to latest, which may help with CI flakiness. It also adds an `isRetryableError` utility that will retry jobs on the following errors:
1. [Failed to create session](https://github.com/mrhenry/polyfill-library/actions/runs/12128696356/job/33818351286)
```txt
Error: Failed to create session.
WebDriverError: This operation was aborted when running "https://hub-cloud.browserstack.com/wd/hub/session" with method "POST" and args "{"capabilities":{"alwaysMatch":{"bstack:options":{"sessionName":"build:null_2024-12-02T23:30:01.135Z","projectName":"polyfill-library","local":true,"video":true,"debug":true,"consoleLogs":"errors","networkLogs":true},"browserName":"chrome","browserVersion":"102.0","webSocketUrl":true},"firstMatch":[{}]}}"
    at startWebDriverSession (file:///home/runner/work/polyfill-library/polyfill-library/node_modules/webdriver/build/index.js:853:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async _WebDriver.newSession (file:///home/runner/work/polyfill-library/polyfill-library/node_modules/webdriver/build/index.js:1547:41)
    at async remote (file:///home/runner/work/polyfill-library/polyfill-library/node_modules/webdriverio/build/index.js:7228:20)
    at async TestJob.run (/home/runner/work/polyfill-library/polyfill-library/test/polyfills/test-job.js:102:19)
```
2. [An unknown server-side error occurred while processing the command](https://github.com/mrhenry/polyfill-library/actions/runs/12148384546/job/33876735290)
```txt
unknown error: WebDriverError: An unknown server-side error occurred while processing the command. when running "window" with method "DELETE"
    at FetchRequest._request (file:///home/runner/work/polyfill-library/polyfill-library/node_modules/webdriver/build/node.js:1652:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Browser.wrapCommandFn (file:///home/runner/work/polyfill-library/polyfill-library/node_modules/@wdio/utils/build/index.js:884:23)
    at async TestJob.run (/home/runner/work/polyfill-library/polyfill-library/test/polyfills/test-job.js:175:4)
```

It also includes https://github.com/mrhenry/polyfill-library/pull/90, which further reduces test flakiness.