### PR TITLE
Adds `RegExp.escape`

### DIFF
--- a/polyfills/RegExp/escape/config.toml
+++ b/polyfills/RegExp/escape/config.toml
@@ -1,0 +1,23 @@
+aliases = [ "es2025" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.EncodeForRegExpEscape",
+	"_ESAbstract.StringToCodePoints",
+]
+spec = "https://tc39.es/proposal-regex-escaping/#sec-regexp.escape"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape"
+
+[browsers]
+android = "*"
+chrome = "*"
+edge = "*"
+edge_mob = "*"
+firefox = "<134"
+firefox_mob = "<134"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+safari = "<18.2"
+ios_saf = "<18.2"
+samsung_mob = "*"

--- a/polyfills/RegExp/escape/detect.js
+++ b/polyfills/RegExp/escape/detect.js
@@ -1,0 +1,1 @@
+"escape" in RegExp;

--- a/polyfills/RegExp/escape/polyfill.js
+++ b/polyfills/RegExp/escape/polyfill.js
@@ -1,0 +1,39 @@
+/* global CreateMethodProperty, EncodeForRegExpEscape, StringToCodePoints */
+// 22.2.5.1 RegExp.escape ( S )
+CreateMethodProperty(RegExp, "escape", function escape(S) {
+	// 1. If S is not a String, throw a TypeError exception.
+	if (typeof S !== "string") {
+		throw new TypeError("S must be a string");
+	}
+	// 2. Let escaped be the empty String.
+	var escaped = "";
+	// 3. Let cpList be StringToCodePoints(S).
+	var cpList = StringToCodePoints(S);
+	// 4. For each code point c of cpList, do
+	for (var i = 0; i < cpList.length; i++) {
+		var c = cpList[i];
+		// a. If escaped is the empty String and c is matched by either DecimalDigit or AsciiLetter, then
+		if (
+			escaped === "" &&
+			((c >= 0x0030 && c <= 0x0039) || // 0-9
+				(c >= 0x0041 && c <= 0x005a) || // A-Z
+				(c >= 0x0061 && c <= 0x007a)) // a-z
+		) {
+			// i. NOTE: Escaping a leading digit ensures that output corresponds with pattern text which may be used after a \0 character escape or a DecimalEscape such as \1 and still match S rather than be interpreted as an extension of the preceding escape sequence. Escaping a leading ASCII letter does the same for the context after \c.
+			// ii. Let numericValue be the numeric value of c.
+			var numericValue = c;
+			// iii. Let hex be Number::toString(𝔽(numericValue), 16).
+			var hex = Number.prototype.toString.call(numericValue, 16);
+			// iv. Assert: The length of hex is 2.
+			// v. Set escaped to the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS), "x", and hex.
+			escaped = "\\x" + hex;
+		}
+		// b. Else,
+		else {
+			// i. Set escaped to the string-concatenation of escaped and EncodeForRegExpEscape(c).
+			escaped += EncodeForRegExpEscape(c);
+		}
+	}
+	// 5. Return escaped.
+	return escaped;
+});

--- a/polyfills/RegExp/escape/polyfill.test.js
+++ b/polyfills/RegExp/escape/polyfill.test.js
@@ -1,0 +1,47 @@
+it("is a function", function () {
+	proclaim.isFunction(RegExp.escape);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(RegExp.escape, 1);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(RegExp.escape, "escape");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(RegExp, "escape");
+});
+
+describe("escape", function () {
+	it("escapes special regex characters", function () {
+		proclaim.strictEqual(RegExp.escape("10$"), "\\x310\\$");
+		proclaim.strictEqual(RegExp.escape("abcdefg_123456"), "\\x61bcdefg_123456");
+		proclaim.strictEqual(RegExp.escape("Привет"), "Привет");
+		proclaim.strictEqual(
+			RegExp.escape("(){}[]|,.?*+-^$=<>\\/#&!%:;@~'\"`"),
+			"\\(\\)\\{\\}\\[\\]\\|\\x2c\\.\\?\\*\\+\\x2d\\^\\$\\x3d\\x3c\\x3e\\\\\\/\\x23\\x26\\x21\\x25\\x3a\\x3b\\x40\\x7e\\x27\\x22\\x60"
+		);
+		proclaim.strictEqual(
+			RegExp.escape(
+				"\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF"
+			),
+			"\\t\\n\\v\\f\\r\\x20\\xa0\\u1680\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a\\u202f\\u205f\\u3000\\u2028\\u2029\\ufeff"
+		);
+
+		proclaim.strictEqual(RegExp.escape("💩"), "💩");
+		proclaim.strictEqual(RegExp.escape("\uD83D"), "\\ud83d");
+		proclaim.strictEqual(RegExp.escape("\uDCA9"), "\\udca9");
+		proclaim.strictEqual(RegExp.escape("\uDCA9\uD83D"), "\\udca9\\ud83d");
+	});
+
+	it("throws on non-string input", function () {
+		proclaim.throws(function () {
+			RegExp.escape(42);
+		}, TypeError);
+		proclaim.throws(function () {
+			RegExp.escape({});
+		}, TypeError);
+	});
+});

--- a/polyfills/String/prototype/padEnd/config.toml
+++ b/polyfills/String/prototype/padEnd/config.toml
@@ -2,6 +2,7 @@ aliases = [ "es7", "es2016", "es2017" ]
 dependencies = [
 	"_ESAbstract.CreateMethodProperty",
 	"_ESAbstract.RequireObjectCoercible",
+	"_ESAbstract.StringPad",
 	"_ESAbstract.ToString",
 	"_ESAbstract.ToLength"
 ]

--- a/polyfills/String/prototype/padEnd/polyfill.js
+++ b/polyfills/String/prototype/padEnd/polyfill.js
@@ -1,4 +1,4 @@
-/* global CreateMethodProperty, RequireObjectCoercible, ToLength, ToString */
+/* global CreateMethodProperty, RequireObjectCoercible, StringPad, ToLength, ToString */
 // 21.1.3.13. String.prototype.padEnd( maxLength [ , fillString ] )
 CreateMethodProperty(String.prototype, 'padEnd', function padEnd(maxLength /* [ , fillString ] */) {
 	'use strict';
@@ -22,18 +22,6 @@ CreateMethodProperty(String.prototype, 'padEnd', function padEnd(maxLength /* [ 
 	} else {
 		filler = ToString(fillString);
 	}
-	// 8. If filler is the empty String, return S.
-	if (filler === '') {
-		return S;
-	}
-	// 9. Let fillLen be intMaxLength - stringLength.
-	var fillLen = intMaxLength - stringLength;
-	// 10. Let truncatedStringFiller be the String value consisting of repeated concatenations of filler truncated to length fillLen.
-	var truncatedStringFiller = '';
-	for (var i = 0; i < fillLen; i++) {
-		truncatedStringFiller += filler;
-	}
-	truncatedStringFiller = truncatedStringFiller.substr(0, fillLen);
-	// 11. Return the string-concatenation of S and truncatedStringFiller.
-	return S + truncatedStringFiller;
+	// 8. Return StringPad(S, intMaxLength, filler, end).
+	return StringPad(S, intMaxLength, filler, "END");
 });

--- a/polyfills/String/prototype/padStart/config.toml
+++ b/polyfills/String/prototype/padStart/config.toml
@@ -2,6 +2,7 @@ aliases = [ "es7", "es2016", "es2017" ]
 dependencies = [
 	"_ESAbstract.CreateMethodProperty",
 	"_ESAbstract.RequireObjectCoercible",
+	"_ESAbstract.StringPad",
 	"_ESAbstract.ToString",
 	"_ESAbstract.ToLength"
 ]

--- a/polyfills/String/prototype/padStart/polyfill.js
+++ b/polyfills/String/prototype/padStart/polyfill.js
@@ -1,4 +1,4 @@
-/* global CreateMethodProperty, RequireObjectCoercible, ToLength, ToString */
+/* global CreateMethodProperty, RequireObjectCoercible, StringPad, ToLength, ToString */
 // 21.1.3.14. String.prototype.padStart( maxLength [ , fillString ] )
 CreateMethodProperty(String.prototype, 'padStart', function padStart(maxLength /* [ , fillString ] */) {
 	'use strict';
@@ -22,18 +22,6 @@ CreateMethodProperty(String.prototype, 'padStart', function padStart(maxLength /
 	} else {
 		filler = ToString(fillString);
 	}
-	// 8. If filler is the empty String, return S.
-	if (filler === '') {
-		return S;
-	}
-	// 9. Let fillLen be intMaxLength - stringLength.
-	var fillLen = intMaxLength - stringLength;
-	// 10. Let truncatedStringFiller be the String value consisting of repeated concatenations of filler truncated to length fillLen.
-	var truncatedStringFiller = '';
-	for (var i = 0; i < fillLen; i++) {
-		truncatedStringFiller += filler;
-	}
-	truncatedStringFiller = truncatedStringFiller.substr(0, fillLen);
-	// 11. Return the string-concatenation of truncatedStringFiller and S.
-	return truncatedStringFiller + S;
+	// 8. Return StringPad(S, intMaxLength, filler, start).
+	return StringPad(S, intMaxLength, filler, "START");
 });

--- a/polyfills/_ESAbstract/EncodeForRegExpEscape/config.toml
+++ b/polyfills/_ESAbstract/EncodeForRegExpEscape/config.toml
@@ -1,0 +1,24 @@
+dependencies = [
+  "_ESAbstract.StringPad",
+  "_ESAbstract.StringToCodePoints",
+  "_ESAbstract.UTF16EncodeCodePoint",
+	"_ESAbstract.UnicodeEscape",
+]
+spec = "https://tc39.es/proposal-regex-escaping/#sec-encodeforregexpescape"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+edge_mob = "*"
+firefox = "*"
+firefox_mob = "*"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "*"
+ios_saf = "*"
+samsung_mob = "*"

--- a/polyfills/_ESAbstract/EncodeForRegExpEscape/polyfill.js
+++ b/polyfills/_ESAbstract/EncodeForRegExpEscape/polyfill.js
@@ -1,0 +1,85 @@
+/* global StringPad, StringToCodePoints, UTF16EncodeCodePoint, UnicodeEscape */
+// 22.2.5.1.1 EncodeForRegExpEscape ( c )
+// eslint-disable-next-line no-unused-vars
+function EncodeForRegExpEscape(c) {
+	// 1. If c is matched by SyntaxCharacter or c is U+002F (SOLIDUS), then
+	if (
+		c === 0x005e || // ^
+		c === 0x0024 || // $
+		c === 0x005c || // \
+		c === 0x002e || // .
+		c === 0x002a || // *
+		c === 0x002b || // +
+		c === 0x003f || // ?
+		c === 0x0028 || // (
+		c === 0x0029 || // )
+		c === 0x005b || // [
+		c === 0x005d || // ]
+		c === 0x007b || // {
+		c === 0x007d || // }
+		c === 0x007c || // |
+		c === 0x002f // /
+	) {
+		// a. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and UTF16EncodeCodePoint(c).
+		return "\\" + UTF16EncodeCodePoint(c);
+	}
+	// 2. Else if c is the code point listed in some cell of the “Code Point” column of Table 63, then
+	else if (c >= 0x0009 && c <= 0x000d) {
+		// a. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and the string in the “ControlEscape” column of the row whose “Code Point” column contains c.
+		return (
+			"\\" +
+			{
+				0x0009: "t", // CHARACTER TABULATION
+				0x000a: "n", // LINE FEED
+				0x000b: "v", // LINE TABULATION
+				0x000c: "f", // FORM FEED
+				0x000d: "r" // CARRIAGE RETURN
+			}[c]
+		);
+	}
+	// 3. Let otherPunctuators be the string-concatenation of ",-=<>#&!%:;@~'`" and the code unit 0x0022 (QUOTATION MARK).
+	var otherPunctuators = ",-=<>#&!%:;@~'`\"";
+	// 4. Let toEscape be StringToCodePoints(otherPunctuators).
+	var toEscape = StringToCodePoints(otherPunctuators);
+	// 5. If toEscape contains c, c is matched by either WhiteSpace or LineTerminator, or c has the same numeric value as a leading surrogate or trailing surrogate, then
+	if (
+		toEscape.indexOf(c) > -1 ||
+		// https://www.compart.com/en/unicode/category/Zs
+		c === 0xfeff || // ZERO WIDTH NO-BREAK SPACE
+		c === 0x0020 || // SPACE
+		c === 0x00a0 || // NO-BREAK SPACE
+		c === 0x1680 || // OGHAM SPACE MARK
+		(c >= 0x2000 && c <= 0x200a) || // other spaces
+		c === 0x202f || // NARROW NO-BREAK SPACE
+		c === 0x205f || // MEDIUM MATHEMATICAL SPACE
+		c === 0x3000 || // IDEOGRAPHIC SPACE
+		c === 0x2028 || // LINE SEPARATOR
+		c === 0x2029 || // PARAGRAPH SEPARATOR
+		(c >= 0xd800 && c <= 0xdbff) || // leading surrogate
+		(c >= 0xdc00 && c <= 0xdfff) // trailing surrogate
+	) {
+		// a. Let cNum be the numeric value of c.
+		var cNum = c;
+		// b. If cNum ≤ 0xFF, then
+		if (cNum <= 0x00ff) {
+			// i. Let hex be Number::toString(𝔽(cNum), 16).
+			var hex = Number.prototype.toString.call(cNum, 16);
+			// ii. Return the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS), "x", and StringPad(hex, 2, "0", start).
+			return "\\x" + StringPad(hex, 2, "0", "START");
+		}
+		// c. Let escaped be the empty String.
+		var escaped = "";
+		// d. Let codeUnits be UTF16EncodeCodePoint(c).
+		var codeUnits = UTF16EncodeCodePoint(c);
+		// e. For each code unit cu of codeUnits, do
+		for (var i = 0; i < codeUnits.length; i++) {
+			var cu = codeUnits[i];
+			// i. Set escaped to the string-concatenation of escaped and UnicodeEscape(cu).
+			escaped += UnicodeEscape(cu);
+		}
+		// f. Return escaped.
+		return escaped;
+	}
+	// 6. Return UTF16EncodeCodePoint(c).
+	return UTF16EncodeCodePoint(c);
+}

--- a/polyfills/_ESAbstract/StringPad/config.toml
+++ b/polyfills/_ESAbstract/StringPad/config.toml
@@ -1,0 +1,19 @@
+dependencies = []
+spec = "https://tc39.es/ecma262/#sec-stringpad"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+edge_mob = "*"
+firefox = "*"
+firefox_mob = "*"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "*"
+ios_saf = "*"
+samsung_mob = "*"

--- a/polyfills/_ESAbstract/StringPad/polyfill.js
+++ b/polyfills/_ESAbstract/StringPad/polyfill.js
@@ -1,0 +1,30 @@
+// 22.1.3.17.2 StringPad ( S, maxLength, fillString, placement )
+// eslint-disable-next-line no-unused-vars
+function StringPad(S, maxLength, fillString, placement) {
+	// 1. Let stringLength be the length of S.
+	var stringLength = S.length;
+	// 2. If maxLength ≤ stringLength, return S.
+	if (maxLength <= stringLength) {
+		return S;
+	}
+	// 3. If fillString is the empty String, return S.
+	if (fillString === "") {
+		return S;
+	}
+	// 4. Let fillLen be maxLength - stringLength.
+	var fillLen = maxLength - stringLength;
+	// 5. Let truncatedStringFiller be the String value consisting of repeated concatenations of fillString truncated to length fillLen.
+	var truncatedStringFiller = "";
+	for (var i = 0; i < fillLen; i++) {
+		truncatedStringFiller += fillString;
+	}
+	truncatedStringFiller = truncatedStringFiller.substr(0, fillLen);
+	// 6. If placement is start, return the string-concatenation of truncatedStringFiller and S.
+	if (placement === "START") {
+		return truncatedStringFiller + S;
+	}
+	// 7. Else, return the string-concatenation of S and truncatedStringFiller.
+	else {
+		return S + truncatedStringFiller;
+	}
+}

--- a/polyfills/_ESAbstract/StringToCodePoints/config.toml
+++ b/polyfills/_ESAbstract/StringToCodePoints/config.toml
@@ -1,0 +1,21 @@
+dependencies = [
+  "_ESAbstract.CodePointAt",
+]
+spec = "https://tc39.es/ecma262/#sec-stringtocodepoints"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+edge_mob = "*"
+firefox = "*"
+firefox_mob = "*"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "*"
+ios_saf = "*"
+samsung_mob = "*"

--- a/polyfills/_ESAbstract/StringToCodePoints/polyfill.js
+++ b/polyfills/_ESAbstract/StringToCodePoints/polyfill.js
@@ -1,0 +1,22 @@
+/* global CodePointAt */
+// 11.1.5 Static Semantics: StringToCodePoints ( string )
+// eslint-disable-next-line no-unused-vars
+function StringToCodePoints(string) {
+	// 1. Let codePoints be a new empty List.
+	var codePoints = [];
+	// 2. Let size be the length of string.
+	var size = string.length;
+	// 3. Let position be 0.
+	var position = 0;
+	// 4. Repeat, while position < size,
+	while (position < size) {
+		// a. Let cp be CodePointAt(string, position).
+		var cp = CodePointAt(string, position);
+		// b. Append cp.[[CodePoint]] to codePoints.
+		codePoints.push(cp["[[CodePoint]]"]);
+		// c. Set position to position + cp.[[CodeUnitCount]].
+		position += cp["[[CodeUnitCount]]"];
+	}
+	// 5. Return codePoints.
+	return codePoints;
+}

--- a/polyfills/_ESAbstract/UnicodeEscape/config.toml
+++ b/polyfills/_ESAbstract/UnicodeEscape/config.toml
@@ -1,0 +1,21 @@
+dependencies = [
+	"_ESAbstract.StringPad",
+]
+spec = "https://tc39.es/ecma262/#sec-unicodeescape"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+edge_mob = "*"
+firefox = "*"
+firefox_mob = "*"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "*"
+ios_saf = "*"
+samsung_mob = "*"

--- a/polyfills/_ESAbstract/UnicodeEscape/polyfill.js
+++ b/polyfills/_ESAbstract/UnicodeEscape/polyfill.js
@@ -1,0 +1,12 @@
+/* global StringPad */
+// 25.5.2.4 UnicodeEscape ( C )
+// eslint-disable-next-line no-unused-vars
+function UnicodeEscape(C) {
+	// 1. Let n be the numeric value of C.
+	var n = String.prototype.charCodeAt.call(C, 0);
+	// 2. Assert: n ≤ 0xFFFF.
+	// 3. Let hex be the String representation of n, formatted as a lowercase hexadecimal number.
+	var hex = Number.prototype.toString.call(n, 16);
+	// 4. Return the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS), "u", and StringPad(hex, 4, "0", start).
+	return "\\u" + StringPad(hex, 4, "0", "START");
+}


### PR DESCRIPTION
This PR adds a polyfill for `RegExp.escape`. As part of this, it refactors `String.prototype.padStart` and `String.prototype.padEnd` to use a new `StringPad` abstract operation.