### PR TITLE
add retries to `requestIdleCallback` tests

### DIFF
--- a/polyfills/requestIdleCallback/polyfill.test.js
+++ b/polyfills/requestIdleCallback/polyfill.test.js
@@ -30,6 +30,7 @@ describe('IdleDeadline', function () {
 });
 
 describe('requestIdleCallback', function () {
+	this.retries(3);
 
 	function sleep(busyFor) {
 		busyFor = busyFor + Math.random(); // Prevent Safari while loop optimisation.


### PR DESCRIPTION
These also seem a bit flaky in older Firefox when headless