### PR TITLE
fix `Error.isError`

### DIFF
--- a/polyfills/AggregateError/polyfill.js
+++ b/polyfills/AggregateError/polyfill.js
@@ -1,4 +1,4 @@
-/* global _ErrorConstructor, CreateDataPropertyOrThrow, CreateMethodProperty, IterableToList, Symbol */
+/* global _ErrorConstructor, CreateDataPropertyOrThrow, CreateMethodProperty, IterableToList */
 (function () {
 	var hasErrorCause = (function () {
 		try {
@@ -34,7 +34,7 @@
 	AggregateError.prototype = Object.create(Error.prototype);
 
 	if ('Symbol' in self && 'toStringTag' in self.Symbol) {
-		Object.defineProperty(AggregateError.prototype, Symbol.toStringTag, {
+		Object.defineProperty(AggregateError.prototype, self.Symbol.toStringTag, {
 			configurable: true,
 			enumerable: false,
 			writable: false,

--- a/polyfills/AggregateError/polyfill.js
+++ b/polyfills/AggregateError/polyfill.js
@@ -1,4 +1,4 @@
-/* global _ErrorConstructor, CreateDataPropertyOrThrow, CreateMethodProperty, IterableToList */
+/* global _ErrorConstructor, CreateDataPropertyOrThrow, CreateMethodProperty, IterableToList, Symbol */
 (function () {
 	var hasErrorCause = (function () {
 		try {
@@ -32,6 +32,16 @@
 	}
 
 	AggregateError.prototype = Object.create(Error.prototype);
+
+	if ('Symbol' in self && 'toStringTag' in self.Symbol) {
+		Object.defineProperty(AggregateError.prototype, Symbol.toStringTag, {
+			configurable: true,
+			enumerable: false,
+			writable: false,
+			value: 'Error'
+		});
+	}
+
 	AggregateError.prototype.constructor = AggregateError;
 
 	CreateMethodProperty(self, 'AggregateError', AggregateError);

--- a/polyfills/AggregateError/polyfill.test.js
+++ b/polyfills/AggregateError/polyfill.test.js
@@ -50,6 +50,12 @@ it('has the right prototype', function () {
 	}
 });
 
+if ('Symbol' in self && 'toStringTag' in self.Symbol && self.Symbol.toStringTag in AggregateError.prototype) {
+	it('has the expected toStringTag', function () {
+		proclaim.equal(Object.prototype.toString.call(new AggregateError([])), '[object Error]');
+	});
+}
+
 describe('AggregateError', function () {
 	it("returns an AggregateError", function () {
 		var aggregateError = AggregateError([]);

--- a/polyfills/Error/isError/config.toml
+++ b/polyfills/Error/isError/config.toml
@@ -3,6 +3,7 @@ dependencies = [
 	"_ESAbstract.CreateMethodProperty",
 	"_ESAbstract.Type",
 	"Object.prototype.toString",
+	"Symbol",
 	"Symbol.toStringTag",
 ]
 spec = "https://tc39.es/proposal-is-error/#sec-error.iserror"

--- a/polyfills/Error/isError/polyfill.js
+++ b/polyfills/Error/isError/polyfill.js
@@ -8,9 +8,10 @@ CreateMethodProperty(Error, "isError", function isError(arg) {
 	}
 	// 2. If argument has an [[ErrorData]] internal slot, return true.
 	// 3. Return false.
-	if (!(Symbol.toStringTag in arg)) {
+	if (Symbol.toStringTag in arg) {
 		var str = Object.prototype.toString.call(arg);
 		return str === "[object Error]" || str === "[object DOMException]";
 	}
+
 	return arg instanceof Error;
 });


### PR DESCRIPTION
When all polyfills are tested together the `Error.isError` tests fail on `AggregateError`.
This is because this polyfilled instance does not produce `[object Error]` through `Object.prototype.toString`.


