### PR TITLE
Adds `<Weak>Map.prototype.getOrInsert<Computed>`

### DIFF
--- a/polyfills/Map/prototype/getOrInsert/config.toml
+++ b/polyfills/Map/prototype/getOrInsert/config.toml
@@ -1,0 +1,24 @@
+aliases = [ "es2026" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"Map",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-map.prototype.getorinsert"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsert"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+firefox = "<144"
+firefox_mob = "<144"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "<26.2"
+ios_saf = "<26.2"
+samsung_mob = "*"

--- a/polyfills/Map/prototype/getOrInsert/detect.js
+++ b/polyfills/Map/prototype/getOrInsert/detect.js
@@ -1,0 +1,2 @@
+/* global Map */
+"getOrInsert" in Map.prototype;

--- a/polyfills/Map/prototype/getOrInsert/polyfill.js
+++ b/polyfills/Map/prototype/getOrInsert/polyfill.js
@@ -1,0 +1,21 @@
+/* global CreateMethodProperty, Map */
+// 24.1.3.7 Map.prototype.getOrInsert ( key, value )
+CreateMethodProperty(Map.prototype, "getOrInsert", function getOrInsert(key, value) {
+	// 1. Let M be the this value.
+	var M = this;
+	// 2. Perform ? RequireInternalSlot(M, [[MapData]]).
+	Map.prototype.has.call(M);
+	// 3. Set key to CanonicalizeKeyedCollectionKey(key).
+	// eslint-disable-next-line no-compare-neg-zero
+	if (key === -0) key = 0;
+	// 4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+	// a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+	if (Map.prototype.has.call(M, key)) {
+		return Map.prototype.get.call(M, key);
+	}
+	// 5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+	// 6. Append p to M.[[MapData]].
+	Map.prototype.set.call(M, key, value);
+	// 7. Return value.
+	return value;
+});

--- a/polyfills/Map/prototype/getOrInsert/polyfill.test.js
+++ b/polyfills/Map/prototype/getOrInsert/polyfill.test.js
@@ -1,0 +1,37 @@
+/* global Map */
+
+it("is a function", function () {
+	proclaim.isFunction(Map.prototype.getOrInsert);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Map.prototype.getOrInsert, 2);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Map.prototype.getOrInsert, "getOrInsert");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Map.prototype, "getOrInsert");
+});
+
+describe("getOrInsert", function () {
+	it("gets a value for a key that already exists", function () {
+		var map = new Map([["a", 1]]);
+		proclaim.equal(map.getOrInsert("a", 2), 1);
+		proclaim.equal(map.get("a"), 1);
+	});
+
+	it("inserts a value for a key that doesn't already exist", function () {
+		var map = new Map([["a", 1]]);
+		proclaim.equal(map.getOrInsert("b", 2), 2);
+		proclaim.equal(map.get("b"), 2);
+	});
+
+	it("throws for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Map.prototype.getOrInsert.call({}, "a", 1);
+		}, TypeError);
+	});
+});

--- a/polyfills/Map/prototype/getOrInsertComputed/config.toml
+++ b/polyfills/Map/prototype/getOrInsertComputed/config.toml
@@ -1,0 +1,26 @@
+aliases = [ "es2026" ]
+dependencies = [
+	"_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.IsCallable",
+	"Map",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsertComputed"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+firefox = "<144"
+firefox_mob = "<144"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "<26.2"
+ios_saf = "<26.2"
+samsung_mob = "*"

--- a/polyfills/Map/prototype/getOrInsertComputed/detect.js
+++ b/polyfills/Map/prototype/getOrInsertComputed/detect.js
@@ -1,0 +1,2 @@
+/* global Map */
+"getOrInsertComputed" in Map.prototype;

--- a/polyfills/Map/prototype/getOrInsertComputed/polyfill.js
+++ b/polyfills/Map/prototype/getOrInsertComputed/polyfill.js
@@ -1,0 +1,32 @@
+/* global Call, CreateMethodProperty, IsCallable, Map */
+// 24.1.3.8 Map.prototype.getOrInsertComputed ( key, callback )
+CreateMethodProperty(Map.prototype, "getOrInsertComputed", function getOrInsertComputed(key, callback) {
+	// 1. Let M be the this value.
+	var M = this;
+	// 2. Perform ? RequireInternalSlot(M, [[MapData]]).
+	Map.prototype.has.call(M);
+	// 3. If IsCallable(callback) is false, throw a TypeError exception.
+	if (IsCallable(callback) === false) {
+		throw new TypeError("callback is not callable");
+	}
+	// 4. Set key to CanonicalizeKeyedCollectionKey(key).
+	// eslint-disable-next-line no-compare-neg-zero
+	if (key === -0) key = 0;
+	// 5. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+	// a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+	if (Map.prototype.has.call(M, key)) {
+		return Map.prototype.get.call(M, key);
+	}
+	// 6. Let value be ? Call(callback, undefined, « key »).
+	var value = Call(callback, undefined, [key]);
+	// 7. NOTE: The Map may have been modified during execution of callback.
+	// 8. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+	// a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
+	// i. Set p.[[Value]] to value.
+	// ii. Return value.
+	// 9. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+	// 10. Append p to M.[[MapData]].
+	Map.prototype.set.call(M, key, value);
+	// 11. Return value.
+	return value;
+});

--- a/polyfills/Map/prototype/getOrInsertComputed/polyfill.test.js
+++ b/polyfills/Map/prototype/getOrInsertComputed/polyfill.test.js
@@ -37,13 +37,15 @@ describe("getOrInsertComputed", function () {
 
 	it("throws for an invalid `this`", function () {
 		proclaim.throws(function () {
-			Map.prototype.getOrInsertComputed.call({}, "a", 1);
+			Map.prototype.getOrInsertComputed.call({}, "a", function () {
+				throw new Error("should not have been called");
+			});
 		}, TypeError);
 	});
 
 	it("throws for an invalid `callback`", function () {
 		proclaim.throws(function () {
-			Map.prototype.getOrInsertComputed.call(new Map(), "a", {});
+			new Map().getOrInsertComputed("a", {});
 		}, TypeError);
 	});
 });

--- a/polyfills/Map/prototype/getOrInsertComputed/polyfill.test.js
+++ b/polyfills/Map/prototype/getOrInsertComputed/polyfill.test.js
@@ -1,0 +1,49 @@
+/* global Map */
+
+it("is a function", function () {
+	proclaim.isFunction(Map.prototype.getOrInsertComputed);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(Map.prototype.getOrInsertComputed, 2);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(Map.prototype.getOrInsertComputed, "getOrInsertComputed");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(Map.prototype, "getOrInsertComputed");
+});
+
+describe("getOrInsertComputed", function () {
+	it("gets a value for a key that already exists", function () {
+		var map = new Map([["a", 1]]);
+		var callback = function () {
+			throw new Error("should not have been called");
+		};
+		proclaim.equal(map.getOrInsertComputed("a", callback), 1);
+		proclaim.equal(map.get("a"), 1);
+	});
+
+	it("inserts a value for a key that doesn't already exist", function () {
+		var map = new Map([["a", 1]]);
+		var callback = function (key) {
+			return key + key;
+		};
+		proclaim.equal(map.getOrInsertComputed("b", callback), "bb");
+		proclaim.equal(map.get("b"), "bb");
+	});
+
+	it("throws for an invalid `this`", function () {
+		proclaim.throws(function () {
+			Map.prototype.getOrInsertComputed.call({}, "a", 1);
+		}, TypeError);
+	});
+
+	it("throws for an invalid `callback`", function () {
+		proclaim.throws(function () {
+			Map.prototype.getOrInsertComputed.call(new Map(), "a", {});
+		}, TypeError);
+	});
+});

--- a/polyfills/WeakMap/prototype/getOrInsert/config.toml
+++ b/polyfills/WeakMap/prototype/getOrInsert/config.toml
@@ -1,0 +1,25 @@
+aliases = [ "es2026" ]
+dependencies = [
+	"_ESAbstract.CanBeHeldWeakly",
+	"_ESAbstract.CreateMethodProperty",
+	"WeakMap",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsert"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/getOrInsert"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+firefox = "<144"
+firefox_mob = "<144"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "<26.2"
+ios_saf = "<26.2"
+samsung_mob = "*"

--- a/polyfills/WeakMap/prototype/getOrInsert/detect.js
+++ b/polyfills/WeakMap/prototype/getOrInsert/detect.js
@@ -1,0 +1,2 @@
+/* global WeakMap */
+"getOrInsert" in WeakMap.prototype;

--- a/polyfills/WeakMap/prototype/getOrInsert/polyfill.js
+++ b/polyfills/WeakMap/prototype/getOrInsert/polyfill.js
@@ -1,0 +1,22 @@
+/* global CanBeHeldWeakly, CreateMethodProperty, WeakMap */
+// 24.3.3.4 WeakMap.prototype.getOrInsert ( key, value )
+CreateMethodProperty(WeakMap.prototype, "getOrInsert", function getOrInsert(key, value) {
+	// 1. Let M be the this value.
+	var M = this;
+	// 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
+	WeakMap.prototype.has.call(M);
+	// 3. If CanBeHeldWeakly(key) is false, throw a TypeError exception.
+	if (CanBeHeldWeakly(key) === false) {
+		throw new TypeError("key cannot be held weakly");
+	}
+	// 4. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
+	// a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+	if (WeakMap.prototype.has.call(M, key)) {
+		return WeakMap.prototype.get.call(M, key);
+	}
+	// 5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+	// 6. Append p to M.[[WeakMapData]].
+	WeakMap.prototype.set.call(M, key, value);
+	// 7. Return value.
+	return value;
+});

--- a/polyfills/WeakMap/prototype/getOrInsert/polyfill.test.js
+++ b/polyfills/WeakMap/prototype/getOrInsert/polyfill.test.js
@@ -1,0 +1,45 @@
+/* global WeakMap */
+
+it("is a function", function () {
+	proclaim.isFunction(WeakMap.prototype.getOrInsert);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(WeakMap.prototype.getOrInsert, 2);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(WeakMap.prototype.getOrInsert, "getOrInsert");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(WeakMap.prototype, "getOrInsert");
+});
+
+describe("getOrInsert", function () {
+	it("gets a value for a key that already exists", function () {
+		var key = {};
+		var map = new WeakMap([[key, 1]]);
+		proclaim.equal(map.getOrInsert(key, 2), 1);
+		proclaim.equal(map.get(key), 1);
+	});
+
+	it("inserts a value for a key that doesn't already exist", function () {
+		var key = {};
+		var map = new WeakMap([[{}, 1]]);
+		proclaim.equal(map.getOrInsert(key, 2), 2);
+		proclaim.equal(map.get(key), 2);
+	});
+
+	it("throws for an invalid `this`", function () {
+		proclaim.throws(function () {
+			WeakMap.prototype.getOrInsert.call({}, {}, 1);
+		}, TypeError);
+	});
+
+	it("throws for an invalid `key`", function () {
+		proclaim.throws(function () {
+			WeakMap.prototype.getOrInsert.call(new WeakMap(), "a", 1);
+		}, TypeError);
+	});
+});

--- a/polyfills/WeakMap/prototype/getOrInsert/polyfill.test.js
+++ b/polyfills/WeakMap/prototype/getOrInsert/polyfill.test.js
@@ -39,7 +39,7 @@ describe("getOrInsert", function () {
 
 	it("throws for an invalid `key`", function () {
 		proclaim.throws(function () {
-			WeakMap.prototype.getOrInsert.call(new WeakMap(), "a", 1);
+			new WeakMap().getOrInsert("a", 1);
 		}, TypeError);
 	});
 });

--- a/polyfills/WeakMap/prototype/getOrInsertComputed/config.toml
+++ b/polyfills/WeakMap/prototype/getOrInsertComputed/config.toml
@@ -1,0 +1,27 @@
+aliases = [ "es2026" ]
+dependencies = [
+	"_ESAbstract.Call",
+	"_ESAbstract.CanBeHeldWeakly",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.IsCallable",
+	"WeakMap",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsertcomputed"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/getOrInsertComputed"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+firefox = "<144"
+firefox_mob = "<144"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "<26.2"
+ios_saf = "<26.2"
+samsung_mob = "*"

--- a/polyfills/WeakMap/prototype/getOrInsertComputed/detect.js
+++ b/polyfills/WeakMap/prototype/getOrInsertComputed/detect.js
@@ -1,0 +1,2 @@
+/* global WeakMap */
+"getOrInsertComputed" in WeakMap.prototype;

--- a/polyfills/WeakMap/prototype/getOrInsertComputed/polyfill.js
+++ b/polyfills/WeakMap/prototype/getOrInsertComputed/polyfill.js
@@ -1,0 +1,33 @@
+/* global Call, CanBeHeldWeakly, CreateMethodProperty, IsCallable, WeakMap */
+// 24.3.3.5 WeakMap.prototype.getOrInsertComputed ( key, callback )
+CreateMethodProperty(WeakMap.prototype, "getOrInsertComputed", function getOrInsertComputed(key, callback) {
+	// 1. Let M be the this value.
+	var M = this;
+	// 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
+	WeakMap.prototype.has.call(M);
+	// 3. If CanBeHeldWeakly(key) is false, throw a TypeError exception.
+	if (CanBeHeldWeakly(key) === false) {
+		throw new TypeError("key cannot be held weakly");
+	}
+	// 4. If IsCallable(callback) is false, throw a TypeError exception.
+	if (IsCallable(callback) === false) {
+		throw new TypeError("callback is not callable");
+	}
+	// 5. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
+	// a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+	if (WeakMap.prototype.has.call(M, key)) {
+		return WeakMap.prototype.get.call(M, key);
+	}
+	// 6. Let value be ? Call(callback, undefined, « key »).
+	var value = Call(callback, undefined, [key]);
+	// 7. NOTE: The WeakMap may have been modified during execution of callback.
+	// 8. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
+	// a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
+	// i. Set p.[[Value]] to value.
+	// ii. Return value.
+	// 9. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+	// 10. Append p to M.[[WeakMapData]].
+	WeakMap.prototype.set.call(M, key, value);
+	// 11. Return value.
+	return value;
+});

--- a/polyfills/WeakMap/prototype/getOrInsertComputed/polyfill.test.js
+++ b/polyfills/WeakMap/prototype/getOrInsertComputed/polyfill.test.js
@@ -1,0 +1,57 @@
+/* global WeakMap */
+
+it("is a function", function () {
+	proclaim.isFunction(WeakMap.prototype.getOrInsertComputed);
+});
+
+it("has correct arity", function () {
+	proclaim.arity(WeakMap.prototype.getOrInsertComputed, 2);
+});
+
+it("has correct name", function () {
+	proclaim.hasName(WeakMap.prototype.getOrInsertComputed, "getOrInsertComputed");
+});
+
+it("is not enumerable", function () {
+	proclaim.isNotEnumerable(WeakMap.prototype, "getOrInsertComputed");
+});
+
+describe("getOrInsertComputed", function () {
+	it("gets a value for a key that already exists", function () {
+		var key = {};
+		var map = new WeakMap([[key, 1]]);
+		var callback = function () {
+			throw new Error("should not have been called");
+		};
+		proclaim.equal(map.getOrInsertComputed(key, callback), 1);
+		proclaim.equal(map.get(key), 1);
+	});
+
+	it("inserts a value for a key that doesn't already exist", function () {
+		var key = { k: 2 };
+		var map = new WeakMap([[{}, 1]]);
+		var callback = function (key) {
+			return key.k;
+		};
+		proclaim.equal(map.getOrInsertComputed(key, callback), 2);
+		proclaim.equal(map.get(key), 2);
+	});
+
+	it("throws for an invalid `this`", function () {
+		proclaim.throws(function () {
+			WeakMap.prototype.getOrInsertComputed.call({}, {}, 1);
+		}, TypeError);
+	});
+
+	it("throws for an invalid `key`", function () {
+		proclaim.throws(function () {
+			WeakMap.prototype.getOrInsertComputed.call(new WeakMap(), "a", 1);
+		}, TypeError);
+	});
+
+	it("throws for an invalid `callback`", function () {
+		proclaim.throws(function () {
+			WeakMap.prototype.getOrInsertComputed.call(new WeakMap(), {}, {});
+		}, TypeError);
+	});
+});

--- a/polyfills/WeakMap/prototype/getOrInsertComputed/polyfill.test.js
+++ b/polyfills/WeakMap/prototype/getOrInsertComputed/polyfill.test.js
@@ -39,19 +39,23 @@ describe("getOrInsertComputed", function () {
 
 	it("throws for an invalid `this`", function () {
 		proclaim.throws(function () {
-			WeakMap.prototype.getOrInsertComputed.call({}, {}, 1);
+			WeakMap.prototype.getOrInsertComputed.call({}, {}, function () {
+				throw new Error("should not have been called");
+			});
 		}, TypeError);
 	});
 
 	it("throws for an invalid `key`", function () {
 		proclaim.throws(function () {
-			WeakMap.prototype.getOrInsertComputed.call(new WeakMap(), "a", 1);
+			new WeakMap().getOrInsertComputed("a", function () {
+				throw new Error("should not have been called");
+			});
 		}, TypeError);
 	});
 
 	it("throws for an invalid `callback`", function () {
 		proclaim.throws(function () {
-			WeakMap.prototype.getOrInsertComputed.call(new WeakMap(), {}, {});
+			new WeakMap().getOrInsertComputed({}, {});
 		}, TypeError);
 	});
 });

--- a/polyfills/_ESAbstract/CanBeHeldWeakly/config.toml
+++ b/polyfills/_ESAbstract/CanBeHeldWeakly/config.toml
@@ -1,0 +1,21 @@
+dependencies = [
+	"WeakMap",
+]
+spec = "https://tc39.es/ecma262/#sec-canbeheldweakly"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "*"
+edge = "*"
+edge_mob = "*"
+firefox = "*"
+firefox_mob = "*"
+ie = "*"
+ie_mob = "*"
+opera = "*"
+op_mob = "*"
+op_mini = "*"
+safari = "*"
+ios_saf = "*"
+samsung_mob = "*"

--- a/polyfills/_ESAbstract/CanBeHeldWeakly/polyfill.js
+++ b/polyfills/_ESAbstract/CanBeHeldWeakly/polyfill.js
@@ -1,0 +1,16 @@
+/* global WeakMap */
+var weakMap = new WeakMap();
+
+// 9.13 CanBeHeldWeakly ( v )
+function CanBeHeldWeakly(v) { // eslint-disable-line no-unused-vars
+	try {
+		// 1. If v is an Object, return true.
+		// 2. If v is a Symbol and KeyForSymbol(v) is undefined, return true.
+		weakMap.set(v, 1);
+		weakMap.delete(v, 1);
+		return true;
+	} catch (_) {
+		// 3. Return false.
+		return false;
+	}
+}


### PR DESCRIPTION
This PR adds the following ES2026 polyfills:
* `Map.prototype.getOrInsert`
* `Map.prototype.getOrInsertComputed`
* `WeakMap.prototype.getOrInsert`
* `WeakMap.prototype.getOrInsertComputed`